### PR TITLE
Various Japanese translation fixes

### DIFF
--- a/ja_JP/ocenaudio_ja_JP.ts
+++ b/ja_JP/ocenaudio_ja_JP.ts
@@ -13,7 +13,7 @@
     </message>
     <message>
         <source>16000</source>
-        <translation></translation>
+        <translation>16000</translation>
     </message>
     <message>
         <source>Hz</source>
@@ -21,35 +21,35 @@
     </message>
     <message>
         <source>48000</source>
-        <translation></translation>
+        <translation>48000</translation>
     </message>
     <message>
         <source>44100</source>
-        <translation></translation>
+        <translation>44100</translation>
     </message>
     <message>
         <source>32000</source>
-        <translation></translation>
+        <translation>32000</translation>
     </message>
     <message>
         <source>22050</source>
-        <translation></translation>
+        <translation>22050</translation>
     </message>
     <message>
         <source>11025</source>
-        <translation></translation>
+        <translation>11025</translation>
     </message>
     <message>
         <source>8000</source>
-        <translation></translation>
+        <translation>8000</translation>
     </message>
     <message>
         <source>6000</source>
-        <translation></translation>
+        <translation>6000</translation>
     </message>
     <message>
         <source>This setting only changes the value of the sample rate. This operation does not resample the signal.</source>
-        <translation>こちらの設定でサンプルレートの値のみ変更する。この操作でシグナルがリサンプルされません。</translation>
+        <translation>こちらの設定でサンプルレートの値のみを変更する。シグナル自体がリサンプルされません。</translation>
     </message>
 </context>
 <context>
@@ -64,7 +64,7 @@
     </message>
     <message>
         <source>New From</source>
-        <translation>新しいやつから</translation>
+        <translation>...から新しく作成</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
@@ -72,19 +72,19 @@
     </message>
     <message>
         <source>&amp;View</source>
-        <translation>&amp;閲覧</translation>
+        <translation>&amp;表示</translation>
     </message>
     <message>
         <source>Display Time Format</source>
-        <translation>時間正式を表示</translation>
+        <translation>時間書式を表示</translation>
     </message>
     <message>
         <source>Vertical Scale Format</source>
-        <translation>縦拡をフォーマット</translation>
+        <translation>縦拡の書式</translation>
     </message>
     <message>
         <source>Spectral Scale Format</source>
-        <translation>分光拡をフォーマット</translation>
+        <translation>分光拡の書式</translation>
     </message>
     <message>
         <source>Zoom</source>
@@ -96,15 +96,15 @@
     </message>
     <message>
         <source>Effec&amp;ts</source>
-        <translation>エフェクト</translation>
+        <translation>効果</translation>
     </message>
     <message>
         <source>Amplitude</source>
-        <translation>広さ</translation>
+        <translation>振幅</translation>
     </message>
     <message>
         <source>Filter</source>
-        <translation>フィルタ</translation>
+        <translation>フィルター</translation>
     </message>
     <message>
         <source>Equalization</source>
@@ -140,7 +140,7 @@
     </message>
     <message>
         <source>New...</source>
-        <translation>新作成...</translation>
+        <translation>新しく作成...</translation>
     </message>
     <message>
         <source>Duplicate</source>
@@ -309,11 +309,11 @@
     </message>
     <message>
         <source>Save All</source>
-        <translation>全保存</translation>
+        <translation>全てを保存</translation>
     </message>
-    <message>
+    <message>　
         <source>Revert to Saved</source>
-        <translation>保存バージョンに復帰する</translation>
+        <translation>保存したバージョンに戻す</translation>
     </message>
     <message>
         <source>Play</source>
@@ -333,7 +333,7 @@
     </message>
     <message>
         <source>All Sound</source>
-        <translation>全サウンド</translation>
+        <translation>全てのサウンド</translation>
     </message>
     <message>
         <source>Selection</source>
@@ -341,7 +341,7 @@
     </message>
     <message>
         <source>Show File Folder...</source>
-        <translation>ファイルフォルダーを表示する...</translation>
+        <translation>ファイルのフォルダーを表示する...</translation>
     </message>
     <message>
         <source>Hide Waveform Navigator</source>
@@ -473,7 +473,7 @@
     </message>
     <message>
         <source>ocenaudio</source>
-        <translation>オセンオーディオ</translation>
+        <translation>ocenaudio</translation>
     </message>
     <message>
         <source>Extra Tracks</source>
@@ -505,7 +505,7 @@
     </message>
     <message>
         <source>Noise</source>
-        <translation>雑音</translation>
+        <translation>ノイズ</translation>
     </message>
     <message>
         <source>DTMF</source>
@@ -590,11 +590,11 @@
     </message>
     <message>
         <source>31-Band Graphic Equalizer...</source>
-        <translation>31条図形等化器...</translation>
+        <translation>31-バンド図形等化器...</translation>
     </message>
     <message>
         <source>11-Band Graphic Equalizer...</source>
-        <translation>11条図形等化器...</translation>
+        <translation>11-バンド図形等化器...</translation>
     </message>
     <message>
         <source>Clipboard</source>
@@ -642,7 +642,7 @@
     </message>
     <message>
         <source>Noise Gate...</source>
-        <translation>雑音ゲート...</translation>
+        <translation>ノイズゲート...</translation>
     </message>
     <message>
         <source>Normalize</source>
@@ -666,7 +666,7 @@
     </message>
     <message>
         <source>Add Random Noise...</source>
-        <translation>ランダムな雑音を追加...</translation>
+        <translation>ランダムなノイズを追加...</translation>
     </message>
     <message>
         <source>Invert</source>
@@ -710,11 +710,11 @@
     </message>
     <message>
         <source>Meta+Space</source>
-        <translation></translation>
+        <translation>Meta+Space</translation>
     </message>
     <message>
         <source>Send Crash Report...</source>
-        <translation type="unfinished"></translation>
+        <translation>クラッシュ報告を送信中...</translation>
     </message>
     <message>
         <source>Preferences</source>
@@ -730,59 +730,59 @@
     </message>
     <message>
         <source>Record Options</source>
-        <translation type="unfinished"></translation>
+        <translation>録音オプション</translation>
     </message>
     <message>
         <source>Preroll</source>
-        <translation type="unfinished"></translation>
+        <translation>プリロール</translation>
     </message>
     <message>
         <source>Ctrl+P</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+P</translation>
     </message>
     <message>
         <source>Extract Audio From Regions</source>
-        <translation type="unfinished"></translation>
+        <translation>領域からオーディオを抜き出す</translation>
     </message>
     <message>
         <source>Quick Open...</source>
-        <translation type="unfinished"></translation>
+        <translation>クイック開き</translation>
     </message>
     <message>
         <source>Noise Reduction</source>
-        <translation type="unfinished"></translation>
+        <translation>ノイズ減少</translation>
     </message>
     <message>
         <source>Smooth</source>
-        <translation type="unfinished"></translation>
+        <translation>和らげる</translation>
     </message>
     <message>
         <source>Noise Reduction...</source>
-        <translation type="unfinished"></translation>
+        <translation>ノイズ減少...</translation>
     </message>
     <message>
         <source>Automatic Noise Reduction</source>
-        <translation type="unfinished"></translation>
+        <translation>ノイズを自動的に減少する</translation>
     </message>
     <message>
         <source>Playback Options</source>
-        <translation type="unfinished"></translation>
+        <translation>再生オプション</translation>
     </message>
     <message>
         <source>Record Mixer Config...</source>
-        <translation type="unfinished"></translation>
+        <translation>録音ミクサー設定...</translation>
     </message>
     <message>
         <source>Playback Mixer Config...</source>
-        <translation type="unfinished"></translation>
+        <translation>再生ミクサー設定...</translation>
     </message>
     <message>
         <source>Destructive Recording</source>
-        <translation type="unfinished"></translation>
+        <translation>破壊的な録音</translation>
     </message>
     <message>
         <source>Ctrl+D</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+D</translation>
     </message>
 </context>
 <context>
@@ -793,11 +793,11 @@
     </message>
     <message>
         <source>00:00:00.000</source>
-        <translation></translation>
+        <translation>00:00:00.000</translation>
     </message>
     <message>
         <source>View</source>
-        <translation>ビュー</translation>
+        <translation>表示</translation>
     </message>
     <message>
         <source>Selections</source>
@@ -876,15 +876,15 @@
     </message>
     <message>
         <source>Add Noise</source>
-        <translation>雑音を追加</translation>
+        <translation>ノイズを追加</translation>
     </message>
     <message>
         <source>Adding Noise</source>
-        <translation>雑音追加中</translation>
+        <translation>ノイズ追加中</translation>
     </message>
     <message>
         <source>Addition of Noise</source>
-        <translation>雑音の追加</translation>
+        <translation>ノイズの追加</translation>
     </message>
 </context>
 <context>
@@ -995,7 +995,7 @@
     </message>
     <message>
         <source>20.00 Hz</source>
-        <translation></translation>
+        <translation>20.00 Hz</translation>
     </message>
     <message>
         <source>Applying Delay</source>
@@ -1062,7 +1062,7 @@
     </message>
     <message>
         <source>In current version, ocenaudio uses DIRAC LE library that supports only one audio channel with sampling rate of 44100 Hz or 48000 Hz.</source>
-        <translation type="unfinished"></translation>
+        <translation>現在のocenaudioバージョン上で　利用されてるDIRAC LEライブラリが44100 Hz 又は 48000 Hzサンプルレートオーディオチャンネル一つしか対応されていません。</translation>
     </message>
     <message>
         <source>Time and Pitch Adjust</source>
@@ -1129,7 +1129,7 @@
     </message>
     <message>
         <source>Noise Gate</source>
-        <translation>雑音ゲート</translation>
+        <translation>ノイズゲート</translation>
     </message>
     <message>
         <source>-60 dB</source>
@@ -1185,38 +1185,38 @@
     </message>
     <message>
         <source>Applying Compressor</source>
-        <translation type="unfinished"></translation>
+        <translation>圧縮器を適用中</translation>
     </message>
     <message>
         <source>Applying Expansor</source>
-        <translation type="unfinished"></translation>
+        <translation>拡張器を適用中</translation>
     </message>
     <message>
         <source>Expansor</source>
-        <translation type="unfinished"></translation>
+        <translation>拡張器</translation>
     </message>
     <message>
         <source>Applying Limiter</source>
-        <translation type="unfinished"></translation>
+        <translation>制限器を適用中</translation>
     </message>
     <message>
         <source>Applying Noise Gate</source>
-        <translation type="unfinished"></translation>
+        <translation>ノイズゲートを適用中</translation>
     </message>
 </context>
 <context>
     <name>QFadeDialog</name>
     <message>
         <source>Apply Fade</source>
-        <translation type="unfinished"></translation>
+        <translation>フェードを適用する</translation>
     </message>
     <message>
         <source>Fade Options</source>
-        <translation type="unfinished"></translation>
+        <translation>フェードオプション</translation>
     </message>
     <message>
         <source>Direction</source>
-        <translation type="unfinished"></translation>
+        <translation>方向</translation>
     </message>
     <message>
         <source>Fade In</source>
@@ -1228,7 +1228,7 @@
     </message>
     <message>
         <source>Curve</source>
-        <translation type="unfinished"></translation>
+        <translation>カーブ</translation>
     </message>
     <message>
         <source>Linear</source>
@@ -1236,27 +1236,27 @@
     </message>
     <message>
         <source>Cosine</source>
-        <translation type="unfinished"></translation>
+        <translation>コサイン（余弦）</translation>
     </message>
     <message>
         <source>Exponential</source>
-        <translation type="unfinished"></translation>
+        <translation>指数</translation>
     </message>
     <message>
         <source>Use this curve for all fade operations</source>
-        <translation type="unfinished"></translation>
+        <translation>全てのフェードにこのカーブを使用する</translation>
     </message>
     <message>
         <source>S-Curve</source>
-        <translation type="unfinished"></translation>
+        <translation>Sカーブ</translation>
     </message>
     <message>
         <source>Logarithmic</source>
-        <translation type="unfinished"></translation>
+        <translation>対数的</translation>
     </message>
     <message>
         <source>Applying %1 </source>
-        <translation>%1 を適用中 </translation>
+        <translation>%1 を適用中</translation>
     </message>
 </context>
 <context>
@@ -1271,11 +1271,11 @@
     </message>
     <message>
         <source>Passband Limit</source>
-        <translation type="unfinished"></translation>
+        <translation>パスバンドの制限</translation>
     </message>
     <message>
         <source>10,6 ms</source>
-        <translation></translation>
+        <translation>10,6 ms</translation>
     </message>
     <message>
         <source>Highpass</source>
@@ -1283,27 +1283,27 @@
     </message>
     <message>
         <source>Bandpass</source>
-        <translation type="unfinished"></translation>
+        <translation>バンドパス</translation>
     </message>
     <message>
         <source>Passband Limits</source>
-        <translation type="unfinished"></translation>
+        <translation>パスバンドの制限</translation>
     </message>
     <message>
         <source>Bandstop</source>
-        <translation type="unfinished"></translation>
+        <translation>バンドストップ</translation>
     </message>
     <message>
         <source>Rolloff</source>
-        <translation type="unfinished"></translation>
+        <translation>ロールオフ</translation>
     </message>
     <message>
         <source>Passband Atenuation</source>
-        <translation type="unfinished"></translation>
+        <translation>パスバンドの減衰</translation>
     </message>
     <message>
         <source>%1 dB/decade</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 dB/decade</translation>
     </message>
     <message>
         <source>Applying Lowpass Filter</source>
@@ -1323,19 +1323,19 @@
     </message>
     <message>
         <source>Applying Bandpass Filter</source>
-        <translation type="unfinished"></translation>
+        <translation>バンドパスフィルターを適用中</translation>
     </message>
     <message>
         <source>Bandpass Filter</source>
-        <translation type="unfinished"></translation>
+        <translation>バンドパスフィルター</translation>
     </message>
     <message>
         <source>Applying Bandstop Filter</source>
-        <translation type="unfinished"></translation>
+        <translation>帯域除去フィルターを適用中</translation>
     </message>
     <message>
         <source>Bandstop Filter</source>
-        <translation></translation>
+        <translation>バンドストップフィルター</translation>
     </message>
 </context>
 <context>
@@ -1350,15 +1350,15 @@
     </message>
     <message>
         <source>-25.0</source>
-        <translation></translation>
+        <translation>-25.0</translation>
     </message>
     <message>
         <source>dB</source>
-        <translation></translation>
+        <translation>dB</translation>
     </message>
     <message>
         <source>Invert</source>
-        <translation type="unfinished"></translation>
+        <translation>逆にする</translation>
     </message>
     <message>
         <source>Right</source>
@@ -1370,19 +1370,19 @@
     </message>
     <message>
         <source>Normalize to</source>
-        <translation type="unfinished"></translation>
+        <translation>に正常化する</translation>
     </message>
     <message>
         <source>Remove DC before normalizing</source>
-        <translation type="unfinished"></translation>
+        <translation>正常化する前に、DCを抜く</translation>
     </message>
     <message>
         <source>Normalize Channels Independently</source>
-        <translation type="unfinished"></translation>
+        <translation>単独的にチャンネルを正常化する</translation>
     </message>
     <message>
         <source>DC Offset</source>
-        <translation type="unfinished">DCオフセット</translation>
+        <translation>DCオフセット</translation>
     </message>
     <message>
         <source>%</source>
@@ -1390,11 +1390,11 @@
     </message>
     <message>
         <source>Gain Unit</source>
-        <translation type="unfinished"></translation>
+        <translation>増幅単位</translation>
     </message>
     <message>
         <source>Percentual</source>
-        <translation type="unfinished"></translation>
+        <translation>比率</translation>
     </message>
     <message>
         <source>Decibels</source>
@@ -1402,222 +1402,222 @@
     </message>
     <message>
         <source>Offset</source>
-        <translation type="unfinished"></translation>
+        <translation>オフセット</translation>
     </message>
     <message>
         <source>Change Gain</source>
-        <translation type="unfinished"></translation>
+        <translation>増幅を変更する</translation>
     </message>
     <message>
         <source>Amplitude</source>
-        <translation>広さ</translation>
+        <translation>振幅</translation>
     </message>
     <message>
         <source>Changing gain</source>
-        <translation type="unfinished"></translation>
+        <translation>増幅を変更中</translation>
     </message>
     <message>
         <source>Normalizing</source>
-        <translation type="unfinished"></translation>
+        <translation>正常化中</translation>
     </message>
     <message>
         <source>Changing DC offset</source>
-        <translation type="unfinished"></translation>
+        <translation>DCオフセットを変更中</translation>
     </message>
     <message>
         <source>Change DC Offset</source>
-        <translation type="unfinished"></translation>
+        <translation>DCオフセットを変更</translation>
     </message>
     <message>
         <source>Ch #6</source>
-        <translation type="unfinished"></translation>
+        <translation>Ch #6</translation>
     </message>
     <message>
         <source>Ch #7</source>
-        <translation type="unfinished"></translation>
+        <translation>Ch #7</translation>
     </message>
     <message>
         <source>Ch #3</source>
-        <translation type="unfinished"></translation>
+        <translation>Ch #3</translation>
     </message>
     <message>
         <source>Ch #8</source>
-        <translation type="unfinished"></translation>
+        <translation>Ch #8</translation>
     </message>
     <message>
         <source>Ch #4</source>
-        <translation type="unfinished"></translation>
+        <translation>Ch #4</translation>
     </message>
     <message>
         <source>Ch #5</source>
-        <translation type="unfinished"></translation>
+        <translation>Ch #5</translation>
     </message>
     <message>
         <source>Show channel names</source>
-        <translation type="unfinished"></translation>
+        <translation>チャンネル名を表示する</translation>
     </message>
     <message>
         <source>Lock channels</source>
-        <translation type="unfinished"></translation>
+        <translation>チャンネルをロック</translation>
     </message>
     <message>
         <source>Limit gain values to avoid clipping</source>
-        <translation type="unfinished"></translation>
+        <translation>クリップされない様　増幅値を制限する</translation>
     </message>
     <message>
         <source>Limit offset values to avoid clipping</source>
-        <translation type="unfinished"></translation>
+        <translation>クリップされない様　オフセット値を制限する</translation>
     </message>
     <message>
         <source>Lock Channels</source>
-        <translation type="unfinished"></translation>
+        <translation>チャンネルをロック</translation>
     </message>
     <message>
         <source>Channel %1</source>
-        <translation type="unfinished"></translation>
+        <translation>チャンネル %1</translation>
     </message>
 </context>
 <context>
     <name>QGraphEqWidget</name>
     <message>
         <source>Form</source>
-        <translation></translation>
+        <translation>形</translation>
     </message>
     <message>
         <source>20 dB</source>
-        <translation></translation>
+        <translation>20 dB</translation>
     </message>
     <message>
         <source>0 dB</source>
-        <translation></translation>
+        <translation>0 dB</translation>
     </message>
     <message>
         <source>-20 dB</source>
-        <translation></translation>
+        <translation>20 dB</translation>
     </message>
     <message>
         <source>20</source>
-        <translation></translation>
+        <translation>20</translation>
     </message>
     <message>
         <source>25</source>
-        <translation></translation>
+        <translation>25</translation>
     </message>
     <message>
         <source>31.5</source>
-        <translation></translation>
+        <translation>31.5</translation>
     </message>
     <message>
         <source>40</source>
-        <translation></translation>
+        <translation>40</translation>
     </message>
     <message>
         <source>50</source>
-        <translation></translation>
+        <translation>50</translation>
     </message>
     <message>
         <source>63</source>
-        <translation></translation>
+        <translation>63</translation>
     </message>
     <message>
         <source>80</source>
-        <translation></translation>
+        <translation>80</translation>
     </message>
     <message>
         <source>100</source>
-        <translation></translation>
+        <translation>100</translation>
     </message>
     <message>
         <source>125</source>
-        <translation></translation>
+        <translation>125</translation>
     </message>
     <message>
         <source>160</source>
-        <translation></translation>
+        <translation>160</translation>
     </message>
     <message>
         <source>200</source>
-        <translation></translation>
+        <translation>200</translation>
     </message>
     <message>
         <source>250</source>
-        <translation></translation>
+        <translation>250</translation>
     </message>
     <message>
         <source>315</source>
-        <translation></translation>
+        <translation>315</translation>
     </message>
     <message>
         <source>400</source>
-        <translation></translation>
+        <translation>400</translation>
     </message>
     <message>
         <source>500</source>
-        <translation></translation>
+        <translation>500</translation>
     </message>
     <message>
         <source>630</source>
-        <translation></translation>
+        <translation>630</translation>
     </message>
     <message>
         <source>800</source>
-        <translation></translation>
+        <translation>800</translation>
     </message>
     <message>
         <source>1k</source>
-        <translation></translation>
+        <translation>1k</translation>
     </message>
     <message>
         <source>1.25k</source>
-        <translation></translation>
+        <translation>1.25k</translation>
     </message>
     <message>
         <source>1.6k</source>
-        <translation></translation>
+        <translation>1.6k</translation>
     </message>
     <message>
         <source>2k</source>
-        <translation></translation>
+        <translation>2k</translation>
     </message>
     <message>
         <source>2.5k</source>
-        <translation></translation>
+        <translation>2.5k</translation>
     </message>
     <message>
         <source>3.15k</source>
-        <translation></translation>
+        <translation>3.15k</translation>
     </message>
     <message>
         <source>4k</source>
-        <translation></translation>
+        <translation>4k</translation>
     </message>
     <message>
         <source>5k</source>
-        <translation></translation>
+        <translation>5k</translation>
     </message>
     <message>
         <source>6.3k</source>
-        <translation></translation>
+        <translation>6.3k</translation>
     </message>
     <message>
         <source>8k</source>
-        <translation></translation>
+        <translation>8k</translation>
     </message>
     <message>
         <source>10k</source>
-        <translation></translation>
+        <translation>10k</translation>
     </message>
     <message>
         <source>12.5k</source>
-        <translation></translation>
+        <translation>12.5k</translation>
     </message>
     <message>
         <source>16k</source>
-        <translation></translation>
+        <translation>16k</translation>
     </message>
     <message>
         <source>20k</source>
-        <translation></translation>
+        <translation>20k</translation>
     </message>
     <message>
         <source>Gain</source>
@@ -1656,7 +1656,7 @@
     </message>
     <message>
         <source>Medium Low</source>
-        <translation>中低</translation>
+        <translation>中-低</translation>
     </message>
     <message>
         <source>Medium</source>
@@ -1664,7 +1664,7 @@
     </message>
     <message>
         <source>Medium High</source>
-        <translation>中高</translation>
+        <translation>中-高</translation>
     </message>
     <message>
         <source>High</source>
@@ -1692,7 +1692,7 @@
     </message>
     <message>
         <source>Limited Variable Bit Rate (ABR)</source>
-        <translation>制限されてる可変ビットレート(ABR)</translation>
+        <translation>制限した可変ビットレート(ABR)</translation>
     </message>
     <message>
         <source>No Gap</source>
@@ -1700,35 +1700,35 @@
     </message>
     <message>
         <source>½ s Gap</source>
-        <translation>½分の1秒隙間</translation>
+        <translation>0.5秒 の隙間</translation>
     </message>
     <message>
         <source>1 s Gap</source>
-        <translation>1秒隙間</translation>
+        <translation>1秒 の隙間</translation>
     </message>
     <message>
         <source>2 s Gap</source>
-        <translation>2秒隙間</translation>
+        <translation>2秒 の隙間</translation>
     </message>
     <message>
         <source>3 s Gap</source>
-        <translation>3秒隙間</translation>
+        <translation>3秒 の隙間</translation>
     </message>
     <message>
         <source>4 s Gap</source>
-        <translation>4秒隙間</translation>
+        <translation>4秒 の隙間</translation>
     </message>
     <message>
         <source>5 s Gap</source>
-        <translation>5秒隙間</translation>
+        <translation>5秒 の隙間</translation>
     </message>
     <message>
         <source>32 bits</source>
-        <translation type="unfinished">16 ビット {32 ?}</translation>
+        <translation>32 ビット</translation>
     </message>
     <message>
         <source>64 bits</source>
-        <translation type="unfinished">16 ビット {64 ?}</translation>
+        <translation>64 ビット</translation>
     </message>
     <message>
         <source>Preview</source>
@@ -1736,49 +1736,49 @@
     </message>
     <message>
         <source>bins</source>
-        <translation type="unfinished"></translation>
+        <translation>ビン</translation>
     </message>
     <message>
         <source>Window Function</source>
-        <translation type="unfinished"></translation>
+        <translation>ウィンドー性能</translation>
     </message>
     <message>
         <source>Number of Bins</source>
-        <translation type="unfinished"></translation>
+        <translation>ビンの数</translation>
     </message>
     <message>
         <source>Scale Kind</source>
-        <translation type="unfinished"></translation>
+        <translation>スケールの種類</translation>
     </message>
     <message>
         <source>Other Options</source>
-        <translation type="unfinished"></translation>
+        <translation>その他の設定</translation>
     </message>
     <message>
         <source>Follow Play Cursor</source>
-        <translation type="unfinished"></translation>
+        <translation>再生カーソルを追う</translation>
     </message>
     <message>
         <source>Separated channels view</source>
-        <translation type="unfinished"></translation>
+        <translation>分かれてるチャネルを表示</translation>
     </message>
     <message>
         <source>Show each audio channel on a separated view.</source>
-        <translation type="unfinished"></translation>
+        <translation>各チャンネルを別に表示する</translation>
     </message>
     <message>
         <source>Display Cursor Position</source>
-        <translation type="unfinished"></translation>
+        <translation>カーソルの位置を表示する</translation>
     </message>
     <message>
         <source>%1 Scale</source>
         <comment>Ex: Linear Scale (Dont remove %1)</comment>
-        <translation type="unfinished"></translation>
+        <translation>%1 スケール</translation>
     </message>
     <message>
         <source>Drop Artwork Here</source>
         <translation>アートワークを
-ここに
+ここにドラッグアンド
 ドロップ</translation>
     </message>
     <message>
@@ -1819,7 +1819,7 @@
     </message>
     <message>
         <source>Channel %1</source>
-        <translation type="unfinished"></translation>
+        <translation>チャンネル %1</translation>
     </message>
     <message>
         <source>Skip</source>
@@ -1827,79 +1827,79 @@
     </message>
     <message>
         <source>Label</source>
-        <translation type="unfinished"></translation>
+        <translation>ラベル</translation>
     </message>
     <message>
         <source>Position</source>
-        <translation type="unfinished"></translation>
+        <translation>位置</translation>
     </message>
     <message>
         <source>Duration</source>
-        <translation type="unfinished">長さ</translation>
+        <translation>長さ</translation>
     </message>
     <message>
         <source>Comment of region “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>領域“%1” の備考</translation>
     </message>
     <message>
         <source>VST</source>
-        <translation type="unfinished">VST</translation>
+        <translation>VST</translation>
     </message>
     <message>
         <source>VST Preferences</source>
-        <translation type="unfinished"></translation>
+        <translation>VSTの詳細設定</translation>
     </message>
     <message>
         <source>No Dithering</source>
-        <translation type="unfinished"></translation>
+        <translation>ディザリングなし</translation>
     </message>
     <message>
         <source>Rectangular PDF</source>
-        <translation type="unfinished"></translation>
+        <translation>長方形のPDF</translation>
     </message>
     <message>
         <source>Triangular PDF</source>
-        <translation type="unfinished"></translation>
+        <translation>三角のPDF</translation>
     </message>
     <message>
         <source>Noise Shaping</source>
-        <translation type="unfinished"></translation>
+        <translation>ノイズ形状</translation>
     </message>
     <message>
         <source>Other</source>
-        <translation type="unfinished">他の</translation>
+        <translation>その他</translation>
     </message>
     <message>
         <source>From stream</source>
-        <translation type="unfinished"></translation>
+        <translation>ストリームから</translation>
     </message>
     <message>
         <source>From &lt;b&gt;%1 Hz&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1 Hz&lt;/b&gt; から</translation>
     </message>
     <message>
         <source>From &lt;b&gt;multiples sample rates&lt;b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;サンプルレートの数倍の数&lt;b&gt;　から</translation>
     </message>
     <message>
         <source>From &lt;b&gt;multiples number of channels&lt;b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;チャンネル数の数倍の数&lt;b&gt; から</translation>
     </message>
     <message>
         <source>From &lt;b&gt;1 channel (mono)&lt;b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;1 チャンネル （モノラル）&lt;b&gt;　から</translation>
     </message>
     <message>
         <source>From &lt;b&gt;2 channels (stereo)&lt;b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;2 チャンネル （ステレオ）&lt;b&gt;　から</translation>
     </message>
     <message>
         <source>From &lt;b&gt;%1 channels&lt;b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1 チャンネル&lt;b&gt;　から</translation>
     </message>
     <message>
         <source>Custom Sample Rate</source>
-        <translation type="unfinished"></translation>
+        <translation>カスタムサンプルレート</translation>
     </message>
 </context>
 <context>
@@ -1910,20 +1910,20 @@
     </message>
     <message>
         <source>ocenaudio</source>
-        <translation>オセンオーディオ</translation>
+        <translation>ocenaudio</translation>
     </message>
     <message>
         <source>Version 2.6.0 (Build 2292)</source>
         <translation>バージョン 2.6.0 (Build 2292)</translation>
     </message>
     <message>
-        <source>© Copyright OcenAudio Team</source>
-        <oldsource>© Copyright 2011 OcenAudio Team</oldsource>
-        <translation>© Copyright OcenAudio Team</translation>
+        <source>© Copyright ocenaudio Team</source>
+        <oldsource>© Copyright 2011 ocenaudio Team</oldsource>
+        <translation>© Copyright ocenaudio Team</translation>
     </message>
     <message>
         <source>All rights reserved.</source>
-        <translation>不許複製。</translation>
+        <translation>All rights reserved.</translation>
     </message>
     <message>
         <source>Version 2.0.0.rc1 (Build 2292)</source>
@@ -1939,24 +1939,24 @@
     </message>
     <message>
         <source>About ocenaudio</source>
-        <translation>オセンオーディオについて</translation>
+        <translation>ocenaudioについて</translation>
     </message>
     <message>
         <source>http://www.ocenaudio.com</source>
-        <translation type="unfinished"></translation>
+        <translation>http://www.ocenaudio.com</translation>
     </message>
 </context>
 <context>
-    <name>QOcenAudioApplication</name>
+    <name>QocenaudioApplication</name>
     <message>
         <source>Stay Updated with ocenaudio!</source>
-        <translation>オセンオーディオを更新しましょう！</translation>
+        <translation>ocenaudioを常に更新しましょう！</translation>
     </message>
     <message>
         <source>A new version might be available.
 Click here and check!</source>
         <translation>新しいバージョンは有る可能性がある。
-ここにて確認してください！</translation>
+確認するのに、ここをクリックしてください！</translation>
     </message>
     <message>
         <source>New release available</source>
@@ -1965,180 +1965,180 @@ Click here and check!</source>
     <message>
         <source>A new ocenaudio version is available.
 Click here to download it.</source>
-        <translation>新しいオセンオーディオのバージョンがあります。
-ダウンロードするに、ここにクリックして下さい。</translation>
+        <translation>新しいocenaudioのバージョンがあります。
+ダウンロードするに、ここをクリックして下さい。</translation>
     </message>
     <message>
         <source>Use ocenaudio 64-bit!</source>
-        <translation type="unfinished"></translation>
+        <translation>ocenaudio 64-bitをご利用ください！</translation>
     </message>
     <message>
         <source>You are using a 64-bit operating system and ocenaudio is available for this architecture. For better performance use the 64-bit version of ocenaudio.</source>
-        <translation type="unfinished"></translation>
+        <translation>64-bitのオペレーティング システムを利用してる様です。より良いパフォーマンスには　ocenaudioの64-bit版をお使いになって下さい。</translation>
     </message>
     <message>
         <source>Regions Comment</source>
-        <translation type="unfinished"></translation>
+        <translation>領域の備考</translation>
     </message>
     <message>
         <source>New Plugin Installed</source>
-        <translation type="unfinished"></translation>
+        <translation>新プラグインインストール完了</translation>
     </message>
 </context>
 <context>
-    <name>QOcenAudioChangeFormatDialog</name>
+    <name>QocenaudioChangeFormatDialog</name>
     <message>
         <source>Convert Audio Format</source>
-        <translation type="unfinished">オーディオ正式を変更</translation>
+        <translation>オーディオ形式を変更</translation>
     </message>
     <message>
         <source>Change Sample Rate</source>
-        <translation type="unfinished"></translation>
+        <translation>サンプルレートを変更</translation>
     </message>
     <message>
         <source>From &lt;b&gt;22050 Hz&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;22050 Hz&lt;/b&gt; から</translation>
     </message>
     <message>
         <source>➨</source>
-        <translation type="unfinished"></translation>
+        <translation>➨</translation>
     </message>
     <message>
         <source>Don&apos;t Change (22050 Hz)</source>
-        <translation type="unfinished"></translation>
+        <translation>(22050 Hz)変更してはいけません</translation>
     </message>
     <message>
         <source>6000 Hz</source>
-        <translation type="unfinished"></translation>
+        <translation>6000 Hz</translation>
     </message>
     <message>
         <source>8000 Hz</source>
-        <translation type="unfinished"></translation>
+        <translation>8000 Hz</translation>
     </message>
     <message>
         <source>11025 Hz</source>
-        <translation type="unfinished"></translation>
+        <translation>11025 Hz</translation>
     </message>
     <message>
         <source>16000 Hz</source>
-        <translation type="unfinished"></translation>
+        <translation>16000 Hz</translation>
     </message>
     <message>
         <source>22050 Hz</source>
-        <translation type="unfinished"></translation>
+        <translation>22050 Hz</translation>
     </message>
     <message>
         <source>24000 Hz</source>
-        <translation type="unfinished"></translation>
+        <translation>24000 Hz</translation>
     </message>
     <message>
         <source>32000 Hz</source>
-        <translation type="unfinished"></translation>
+        <translation>32000 Hz</translation>
     </message>
     <message>
         <source>44100 Hz</source>
-        <translation type="unfinished"></translation>
+        <translation>44100 Hz</translation>
     </message>
     <message>
         <source>88200 Hz</source>
-        <translation type="unfinished"></translation>
+        <translation>88200 Hz</translation>
     </message>
     <message>
         <source>96000 Hz</source>
-        <translation type="unfinished"></translation>
+        <translation>96000 Hz</translation>
     </message>
     <message>
         <source>Change Number of Channels</source>
-        <translation type="unfinished"></translation>
+        <translation>チャンネルの数を変更する</translation>
     </message>
     <message>
         <source>From &lt;b&gt;1 channel (mono)&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>From &lt;b&gt;1 チャンネル　（モノラル）&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Don&apos;t Change (mono)</source>
-        <translation type="unfinished"></translation>
+        <translation>変更してはいけません（モノラル）</translation>
     </message>
     <message>
         <source>2 channels (stereo)</source>
-        <translation type="unfinished"></translation>
+        <translation>2 チャンネル</translation>
     </message>
     <message>
         <source>3 channels</source>
-        <translation type="unfinished"></translation>
+        <translation>3 チャンネル</translation>
     </message>
     <message>
         <source>4 channels</source>
-        <translation type="unfinished"></translation>
+        <translation>4 チャンネル</translation>
     </message>
     <message>
         <source>5 channels</source>
-        <translation type="unfinished"></translation>
+        <translation>5 チャンネル</translation>
     </message>
     <message>
         <source>6 channels</source>
-        <translation type="unfinished"></translation>
+        <translation>6 チャンネル</translation>
     </message>
     <message>
         <source>7 channels</source>
-        <translation type="unfinished"></translation>
+        <translation>7 チャンネル</translation>
     </message>
     <message>
         <source>8 channels</source>
-        <translation type="unfinished"></translation>
+        <translation>8 チャンネル</translation>
     </message>
     <message>
         <source>Just Swap Left/Right Channels</source>
-        <translation type="unfinished"></translation>
+        <translation>左/右チャンネルのみを交換する</translation>
     </message>
     <message>
         <source>Don&apos;t Change</source>
-        <translation type="unfinished"></translation>
+        <translation>変更してはいけません</translation>
     </message>
     <message>
         <source>Select Custom Sample Rate</source>
-        <translation type="unfinished"></translation>
+        <translation>カスタムサンプルレートを選ぶ</translation>
     </message>
     <message>
         <source>Custom Sample Rate (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>カスタムサンプルレート(%1)</translation>
     </message>
     <message>
         <source>1 channel (mono)</source>
-        <translation type="unfinished"></translation>
+        <translation>1 チャンネル (モノラル）</translation>
     </message>
     <message>
         <source>%1 channels</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 チャンネル</translation>
     </message>
     <message>
         <source>Output
 Channel
 #%1</source>
-        <translation type="unfinished"></translation>
+        <translation>アウトプット</translation>
     </message>
     <message>
         <source>Channel #%1</source>
-        <translation type="unfinished"></translation>
+        <translation>チャンネル #%1</translation>
     </message>
 </context>
 <context>
-    <name>QOcenAudioFftAnalysisDialog</name>
+    <name>QocenaudioFftAnalysisDialog</name>
     <message>
         <source>FFT Analysis</source>
         <translation>FFT解析</translation>
     </message>
     <message>
         <source>%1 Window | %2 %3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 ウィンドー | %2 %3</translation>
     </message>
     <message>
         <source>Updating FFT ...</source>
-        <translation type="unfinished"></translation>
+        <translation>FFT更新中 ...</translation>
     </message>
 </context>
 <context>
-    <name>QOcenAudioMainWindow</name>
+    <name>QocenaudioMainWindow</name>
     <message>
         <source>About</source>
         <translation>バージョン情報</translation>
@@ -2217,7 +2217,7 @@ Channel
     </message>
     <message>
         <source>Apple New Pitch</source>
-        <translation type="unfinished"></translation>
+        <translation>アップルの新音調</translation>
     </message>
     <message>
         <source>Apple Distortion</source>
@@ -2345,7 +2345,7 @@ Channel
     </message>
     <message>
         <source>Spectral Scale in Hz</source>
-        <translation>Hzで分光のスケール</translation>
+        <translation>分光のスケール(Hz)</translation>
     </message>
     <message>
         <source>Show/Hide Regions</source>
@@ -2421,7 +2421,7 @@ Channel
     </message>
     <message>
         <source>Send Crash Report</source>
-        <translation type="unfinished"></translation>
+        <translation type="">クラッシュ報告を送信</translation>
     </message>
     <message>
         <source>Save Sound Copy As ...</source>
@@ -2449,11 +2449,11 @@ Channel
     </message>
     <message>
         <source>Separate</source>
-        <translation>別々</translation>
+        <translation>分ける</translation>
     </message>
     <message>
         <source>Single</source>
-        <translation>合体</translation>
+        <translation>纏める</translation>
     </message>
     <message>
         <source>Save Each Selection Prefixed With ...</source>
@@ -2493,7 +2493,7 @@ Channel
     </message>
     <message>
         <source>The maximum duration of a ringtone to itunes is 30s. To proceed you must select or cut your audio up to 30s.</source>
-        <translation>itunesで着メロの最大長さは30秒に限られています。続行するに、着メロファイルを30秒以下に調整下さい。</translation>
+        <translation>itunesで着メロの最大長さは30秒に限られています。続行するに、着メロファイルを 30秒 以下に調整して下さい。</translation>
     </message>
     <message>
         <source>%1</source>
@@ -2501,7 +2501,7 @@ Channel
     </message>
     <message>
         <source>Do you want to revert to the most recently saved version of the document “%1”?</source>
-        <translation>一番最近の“%1”に復帰しますか？</translation>
+        <translation>一番最近の“%1” に復帰しますか？</translation>
     </message>
     <message>
         <source>Your current changes will be lost.</source>
@@ -2537,7 +2537,7 @@ Channel
     </message>
     <message>
         <source>If you proceed all metadata informations (artist name, album name, artwork) will be removed from this file.</source>
-        <translation>全てのメタデータ情報（アーティストの名前、アルバム名、アートワーク）がこのファイルから省かれます。</translation>
+        <translation>全てのメタデータ情報（アーティスト名、アルバム名、アートワーク）がこのファイルから省かれます。</translation>
     </message>
     <message>
         <source>Some markers will be merged because they are very close.</source>
@@ -2549,19 +2549,19 @@ Channel
     </message>
     <message>
         <source>Markers less than 10 ms apart are merged in the split process. You have %1 markers merged.</source>
-        <translation>ファイルを分ける際、マーカーとマーカーの間が10ms以下の場合には、一つに纏まられます。%1　マーカーが纏まられました。</translation>
+        <translation>ファイルを分ける際、マーカーとマーカーの間が10ms以下の場合には、一つに纏まられます。%1 マーカーが纏まられました。</translation>
     </message>
     <message>
         <source>You are about to split your audio by %1 parts. Are you sure you want to proceed?</source>
-        <translation>オーディオが　%1　部分に分けられます。宜しいですか？</translation>
+        <translation>オーディオが　%1 部分に分けられます。宜しいですか？</translation>
     </message>
     <message>
         <source>If you proceed this operation will generate %1 new audio files.</source>
-        <translation>続行すると、%1　の新ファイルが作成されます。</translation>
+        <translation>続行すると、%1 の新ファイルが作成されます。</translation>
     </message>
     <message>
         <source>Part %1 of </source>
-        <translation>の　%1　部</translation>
+        <translation>%1 / </translation>
     </message>
     <message>
         <source>Error</source>
@@ -2737,7 +2737,7 @@ Channel
     </message>
     <message>
         <source>Repeat %1</source>
-        <translation>%1　を繰り返す</translation>
+        <translation>%1 を繰り返す</translation>
     </message>
     <message>
         <source>Copy</source>
@@ -2797,284 +2797,284 @@ Channel
     </message>
     <message>
         <source>The export file format is not compatible with the current audio format!</source>
-        <translation>書き出しファイルフォーマットは現在のオーディオフォーマットと非対応です!</translation>
+        <translation>書き出しファイル形式が現在のオーディオ形式に非対応です！</translation>
     </message>
     <message>
         <source>The export file cannot be create on the destination path!</source>
-        <translation>書き出しファイルが移動先のパスで作成出来ません!</translation>
+        <translation>書き出しファイルが移動先のパスで作成出来ません！</translation>
     </message>
     <message>
         <source>Extract Audio From Regions</source>
-        <translation type="unfinished"></translation>
+        <translation>領域からオーディオを抜き出す</translation>
     </message>
     <message>
         <source>Enable/Disable Preroll on Recording</source>
-        <translation type="unfinished"></translation>
+        <translation>録音のプリロールを有効/無効にする</translation>
     </message>
     <message>
         <source>Select “separate” to save each selection to a different file. If you select “single”, all your selections will be appended and saved to a single file.</source>
-        <translation type="unfinished"></translation>
+        <translation>各選択を別々保存するには「分ける」を選択してください。「総合」をせんたくしますと　全ての選択が一つのファイル総合して　保存されます。</translation>
     </message>
     <message>
         <source>Mix Pasting</source>
-        <translation type="unfinished"></translation>
+        <translation>貼り付けを混ぜる</translation>
     </message>
     <message>
         <source>Loading Signal</source>
-        <translation type="unfinished"></translation>
+        <translation>信号を読み込み中</translation>
     </message>
     <message>
         <source>Generating Signal</source>
-        <translation type="unfinished"></translation>
+        <translation>信号を生成中</translation>
     </message>
     <message>
         <source>Part “%1” of </source>
-        <translation type="unfinished"></translation>
+        <translation>“%1” / </translation>
     </message>
     <message>
         <source>Some regions will be ignored because they are very short.</source>
-        <translation type="unfinished"></translation>
+        <translation>短すぎる領域が無視されます</translation>
     </message>
     <message>
         <source>Regions with less than 10 ms are ignored. You have one region ignored.</source>
-        <translation type="unfinished"></translation>
+        <translation>10 ms以下の領域が無視されます。無視された領域一つが見つかりました。</translation>
     </message>
     <message>
         <source>Regions with less than 10 ms are ignored. You have %1 regions ignored.</source>
-        <translation type="unfinished"></translation>
+        <translation>10 ms以下の領域が無視されます。無視された領域が %1 見つかりました。</translation>
     </message>
     <message>
         <source>You are about to extract %1 regions from your audio. Are you sure you want to proceed?</source>
-        <translation type="unfinished"></translation>
+        <translation>オーディオから　領域　%1 を抜き出します。よろしいですか？</translation>
     </message>
     <message>
         <source>Region “%1” of </source>
-        <translation type="unfinished"></translation>
+        <translation>領域 “%1”　/ </translation>
     </message>
     <message>
         <source>Region %1 of </source>
-        <translation type="unfinished"></translation>
+        <translation>領域 %1　/ </translation>
     </message>
     <message>
         <source>Apple Reverb 2</source>
-        <translation type="unfinished"></translation>
+        <translation>アップル　リバーブ</translation>
     </message>
     <message>
         <source>Swap Channels from Selections</source>
-        <translation type="unfinished"></translation>
+        <translation>選択からチャンネルを交換する</translation>
     </message>
     <message>
         <source>Applying Automatic Noise Reduction</source>
-        <translation type="unfinished"></translation>
+        <translation>ノイズ減少を自動的に適用中</translation>
     </message>
     <message>
         <source>Noise Reduction</source>
-        <translation type="unfinished"></translation>
+        <translation>ノイズ減少</translation>
     </message>
     <message>
         <source>Playback Mixer Config</source>
-        <translation type="unfinished"></translation>
+        <translation>再生するミクサーの設定</translation>
     </message>
     <message>
         <source>Record Mixer Config</source>
-        <translation type="unfinished"></translation>
+        <translation>録音ミクサーの設定</translation>
     </message>
     <message>
         <source>Enable/Disable Destructive Recording</source>
-        <translation type="unfinished"></translation>
+        <translation>破壊的な録音を有効/無効にする</translation>
     </message>
 </context>
 <context>
-    <name>QOcenAudioNoiseReductionWidget</name>
+    <name>QocenaudioNoiseReductionWidget</name>
     <message>
         <source>Form</source>
-        <translation type="unfinished">フォーム</translation>
+        <translation>フォーム</translation>
     </message>
     <message>
         <source>Noise Profiler</source>
-        <translation type="unfinished"></translation>
+        <translation>ノイズプロファイラ</translation>
     </message>
     <message>
         <source>Get profile</source>
-        <translation type="unfinished"></translation>
+        <translation>プロファイラを取得する</translation>
     </message>
     <message>
         <source>Update profile</source>
-        <translation type="unfinished"></translation>
+        <translation>プロファイラを更新する</translation>
     </message>
     <message>
         <source>Noise Reductor</source>
-        <translation type="unfinished"></translation>
+        <translation>ノイズ減少器</translation>
     </message>
     <message>
         <source>Noise</source>
-        <translation type="unfinished">雑音</translation>
+        <translation>ノイズ</translation>
     </message>
     <message>
         <source>Reduction factor</source>
-        <translation type="unfinished"></translation>
+        <translation>減少因子</translation>
     </message>
     <message>
         <source>0 dB</source>
-        <translation type="unfinished"></translation>
+        <translation>0 dB</translation>
     </message>
     <message>
         <source>60 dB</source>
-        <translation type="unfinished"></translation>
+        <translation>60 dB</translation>
     </message>
     <message>
         <source>0.0 dB</source>
-        <translation type="unfinished"></translation>
+        <translation>0.0 dB</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="unfinished"></translation>
+        <translation>アウトプット</translation>
     </message>
     <message>
         <source>Reduce noise</source>
-        <translation type="unfinished"></translation>
+        <translation>ノイズを減少する</translation>
     </message>
     <message>
         <source>Remove noise</source>
-        <translation type="unfinished"></translation>
+        <translation>ノイズを取り除く</translation>
     </message>
     <message>
         <source>Gate Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>ゲート設定</translation>
     </message>
     <message>
         <source>3 bands</source>
-        <translation type="unfinished"></translation>
+        <translation>3 バンド</translation>
     </message>
     <message>
         <source>Smoothing</source>
-        <translation type="unfinished"></translation>
+        <translation>平滑化</translation>
     </message>
     <message>
         <source>Sensitivity</source>
-        <translation type="unfinished"></translation>
+        <translation>敏感さ</translation>
     </message>
     <message>
         <source>Fast</source>
-        <translation type="unfinished">早い</translation>
+        <translation>早い</translation>
     </message>
     <message>
         <source>Slow</source>
-        <translation type="unfinished">遅い</translation>
+        <translation>遅い</translation>
     </message>
     <message>
         <source>Less</source>
-        <translation type="unfinished"></translation>
+        <translation>もっと少なく</translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"></translation>
+        <translation>もっと多く</translation>
     </message>
     <message>
         <source>0.1 ms</source>
-        <translation type="unfinished"></translation>
+        <translation>0.1 ms</translation>
     </message>
     <message>
         <source>5 ms</source>
-        <translation type="unfinished"></translation>
+        <translation>5 ms</translation>
     </message>
     <message>
         <source>6 ㏑(10)</source>
-        <translation type="unfinished"></translation>
+        <translation>6 ㏑(10)</translation>
     </message>
     <message>
         <source>Release</source>
-        <translation type="unfinished">リリース</translation>
+        <translation>リリース</translation>
     </message>
     <message>
         <source>Attack</source>
-        <translation type="unfinished">アタック</translation>
+        <translation>アタック</translation>
     </message>
     <message>
         <source>Window Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>ウィンドー設定</translation>
     </message>
     <message>
         <source>Analysis:</source>
-        <translation type="unfinished"></translation>
+        <translation>解析</translation>
     </message>
     <message>
         <source>Synthesis:</source>
-        <translation type="unfinished"></translation>
+        <translation>合成</translation>
     </message>
     <message>
         <source>Only for Noise Reductor</source>
-        <translation type="unfinished"></translation>
+        <translation>ノイズ減少器用のみ</translation>
     </message>
     <message>
         <source>Size:</source>
-        <translation type="unfinished"></translation>
+        <translation>大きさ</translation>
     </message>
     <message>
         <source>Only for Noise Profiler</source>
-        <translation type="unfinished"></translation>
+        <translation>ノイズプロファイラ用のみ</translation>
     </message>
     <message>
         <source>Overlap:</source>
-        <translation type="unfinished"></translation>
+        <translation>重なり合う：</translation>
     </message>
     <message>
         <source>Updating noise profile...</source>
-        <translation type="unfinished"></translation>
+        <translationノイズプロフィール更新中...></translation>
     </message>
     <message>
         <source>Noise Reduction</source>
-        <translation type="unfinished"></translation>
+        <translation>ノイズ減少</translation>
     </message>
     <message>
         <source>Reducing Noise</source>
-        <translation type="unfinished"></translation>
+        <translation>ノイズを減少中</translation>
     </message>
     <message>
         <source>Removing Noise</source>
-        <translation type="unfinished"></translation>
+        <translation>ノイズを取り除き中</translation>
     </message>
     <message>
         <source>Estimating Noise</source>
-        <translation type="unfinished"></translation>
+        <translation>ノイズを検出中</translation>
     </message>
     <message>
         <source>Creating noise profile...</source>
-        <translation type="unfinished"></translation>
+        <translation>ノイズプロフィールを作成中...</translation>
     </message>
     <message>
         <source>On Update Profile</source>
-        <translation type="unfinished"></translation>
+        <translation>プロフィール更新で</translation>
     </message>
     <message>
         <source>Could not update profile</source>
-        <translation type="unfinished"></translation>
+        <translation>プロフィールを更新できませんでした</translation>
     </message>
     <message>
         <source>The selected audio must have the same configuration of the one used to estimate the noise profile.</source>
-        <translation type="unfinished"></translation>
+        <translation>ノイズプロフィールを検出するには　選択されたオーディオが</translation>
     </message>
 </context>
 <context>
-    <name>QOcenAudioNoiseReductionWidget::Data</name>
+    <name>QocenaudioNoiseReductionWidget::Data</name>
     <message>
         <source>no overlap</source>
-        <translation type="unfinished"></translation>
+        <translation>重なり合い無し</translation>
     </message>
 </context>
 <context>
-    <name>QOcenAudioOpenFilesPlugin</name>
+    <name>QocenaudioOpenFilesPlugin</name>
     <message>
         <source>Opened Files</source>
-        <translation type="unfinished">開かれてるファイル</translation>
+        <translation>開らいてるファイル</translation>
     </message>
     <message>
         <source>Current open files in ocenaudio</source>
-        <translation type="unfinished">現在にオセンオーディオに開かれてるファイル</translation>
+        <translation>ocenaudio上で現在開いてるファイル</translation>
     </message>
 </context>
 <context>
-    <name>QOcenAudioPropertiesDialog</name>
+    <name>QocenaudioPropertiesDialog</name>
     <message>
         <source>Audio Properties</source>
         <translation>サウンドプロパティ</translation>
@@ -3101,27 +3101,27 @@ Channel
     </message>
     <message>
         <source>filename.mp4</source>
-        <translation></translation>
+        <translation>ファイル名.mp4</translation>
     </message>
     <message>
         <source>File Container</source>
-        <translation type="unfinished"></translation>
+        <translation>ファイルコンテナ</translation>
     </message>
     <message>
         <source>MP4</source>
-        <translation></translation>
+        <translation>MP4</translation>
     </message>
     <message>
         <source>Audio Codec</source>
-        <translation type="unfinished"></translation>
+        <translation>オーディオコーデック</translation>
     </message>
     <message>
         <source>AAC Low Complexity</source>
-        <translation type="unfinished"></translation>
+        <translation>AAC-LC（基本機能のみ）</translation>
     </message>
     <message>
         <source>Encoded With</source>
-        <translation type="unfinished"></translation>
+        <translation>でエンコードされた</translation>
     </message>
     <message>
         <source>LAME3.99</source>
@@ -3133,7 +3133,7 @@ Channel
     </message>
     <message>
         <source>192 kbps</source>
-        <translation></translation>
+        <translation>192 kbps</translation>
     </message>
     <message>
         <source>Sample Rate</source>
@@ -3141,7 +3141,7 @@ Channel
     </message>
     <message>
         <source>44100 Hz</source>
-        <translation></translation>
+        <translation>44100 Hz</translation>
     </message>
     <message>
         <source>Channels</source>
@@ -3165,7 +3165,7 @@ Channel
     </message>
     <message>
         <source>26 seconds</source>
-        <translation type="unfinished"></translation>
+        <translation>26秒</translation>
     </message>
     <message>
         <source>Number of Samples</source>
@@ -3173,7 +3173,7 @@ Channel
     </message>
     <message>
         <source>192900</source>
-        <translation></translation>
+        <translation>192900</translation>
     </message>
     <message>
         <source>Size on Memory</source>
@@ -3181,7 +3181,7 @@ Channel
     </message>
     <message>
         <source>100 Kb</source>
-        <translation></translation>
+        <translation>100 Kb</translation>
     </message>
     <message>
         <source>Size on Disk</source>
@@ -3189,43 +3189,43 @@ Channel
     </message>
     <message>
         <source>192 Kb</source>
-        <translation></translation>
+        <translation>192 Kb</translation>
     </message>
     <message>
         <source>Modification Date</source>
-        <translation type="unfinished"></translation>
+        <translation>更新日時</translation>
     </message>
     <message>
         <source>12/09/2014 23:00</source>
-        <translation></translation>
+        <translation>12/09/2014 23:00</translation>
     </message>
     <message>
         <source>Location</source>
-        <translation type="unfinished"></translation>
+        <translation>所</translation>
     </message>
     <message>
         <source>/Users/ruijunior/Music/iTunes/iTunes Media/Music/Enanitos Verdes/Unknown Album/Lamento Boliviano.aif</source>
-        <translation></translation>
+        <translation>/Users/ruijunior/Music/iTunes/iTunes Media/Music/Enanitos Verdes/Unknown Album/Lamento Boliviano.aif</translation>
     </message>
     <message>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>詳細</translation>
     </message>
     <message>
         <source>Song Name</source>
-        <translation type="unfinished"></translation>
+        <translation>曲名</translation>
     </message>
     <message>
         <source>Album Artist</source>
-        <translation type="unfinished"></translation>
+        <translation>アルバムのアーティスト</translation>
     </message>
     <message>
         <source>Composer</source>
-        <translation type="unfinished"></translation>
+        <translation>作者</translation>
     </message>
     <message>
         <source>Grouping</source>
-        <translation type="unfinished"></translation>
+        <translation>分類</translation>
     </message>
     <message>
         <source>Genre</source>
@@ -3237,7 +3237,7 @@ Channel
     </message>
     <message>
         <source>Disk Number</source>
-        <translation>ディスク番号</translation>
+        <translation>ディスクの番号</translation>
     </message>
     <message>
         <source>of</source>
@@ -3249,15 +3249,15 @@ Channel
     </message>
     <message>
         <source>bpm</source>
-        <translation type="unfinished"></translation>
+        <translation>bpm</translation>
     </message>
     <message>
         <source>Keywords</source>
-        <translation type="unfinished"></translation>
+        <translation>キーワード</translation>
     </message>
     <message>
         <source>Comments</source>
-        <translation type="unfinished"></translation>
+        <translation>備考</translation>
     </message>
     <message>
         <source>Artwork</source>
@@ -3265,19 +3265,19 @@ Channel
     </message>
     <message>
         <source>Album Artwork</source>
-        <translation type="unfinished"></translation>
+        <translation>アルバムのアートワーク</translation>
     </message>
     <message>
         <source>PNG / 256 x 256</source>
-        <translation></translation>
+        <translation>PNG / 256 x 256</translation>
     </message>
     <message>
         <source>Change Artwork...</source>
-        <translation>アートワーク変更...</translation>
+        <translation>アートワークを変更...</translation>
     </message>
     <message>
         <source>Markers</source>
-        <translation type="unfinished"></translation>
+        <translation>マーカー</translation>
     </message>
     <message>
         <source>Statistics</source>
@@ -3293,38 +3293,38 @@ Channel
     </message>
     <message>
         <source>Comment of marker #label</source>
-        <translation type="unfinished"></translation>
+        <translation>#labelマーカーの備考</translation>
     </message>
     <message>
         <source>Comment</source>
-        <translation type="unfinished"></translation>
+        <translation>備考</translation>
     </message>
     <message>
         <source>Revert</source>
-        <translation type="unfinished">復帰する</translation>
+        <translation>元に戻す</translation>
     </message>
     <message>
         <source>Close</source>
-        <translation type="unfinished">閉じる</translation>
+        <translation>閉じる</translation>
     </message>
 </context>
 <context>
     <name>QOcenCrashReportDialog</name>
     <message>
         <source>ocenaudio Crashed Previously</source>
-        <translation>オセンオーディオが以前落ちました</translation>
+        <translation>ocenaudioが以前にクラッシュしました</translation>
     </message>
     <message>
         <source>ocenaudio crashed previously</source>
-        <translation>オセンオーディオが以前落ちました</translation>
+        <translation>ocenaudioが以前にクラッシュしました</translation>
     </message>
     <message>
         <source>Do you want to send details on the crash to ocenaudio&apos;s development team?</source>
-        <translation>クラッシュ情報をオセンオーディオ開発者に送信しますか？</translation>
+        <translation>クラッシュ情報をocenaudio開発者に送信しますか？</translation>
     </message>
     <message>
         <source>If you want, you can enter a few lines on what you did before ocenaudio crashed along with other helpful information: sample file, os crash report, screen shots, ...</source>
-        <translation>宜しければ、数文章でクラッシュが発生する迄　何をしたのかと明記して頂けると役に立つ可能性があります：例　サンプルファイル、OS クラッシュレポート、スクショ、等...</translation>
+        <translation>宜しければ、関係のサンプルファイル、OS クラッシュレポート、スクショ、と一緒に　ocenaudioがクラッシュする迄何をなさったのと数文章で説明して頂けると役に立つ可能性があります。</translation>
     </message>
     <message>
         <source>If you agree to be contacted about this bug report enter your email below:</source>
@@ -3367,7 +3367,7 @@ Channel
     </message>
     <message>
         <source>Name</source>
-        <translation>名前</translation>
+        <translation>名</translation>
     </message>
     <message>
         <source>Fade In</source>
@@ -3383,27 +3383,27 @@ Channel
     </message>
     <message>
         <source>½ s Gap</source>
-        <translation>½分の1秒隙間</translation>
+        <translation>0.5 秒の隙間</translation>
     </message>
     <message>
         <source>1 s Gap</source>
-        <translation>1秒隙間</translation>
+        <translation>1 秒の隙間</translation>
     </message>
     <message>
         <source>2 s Gap</source>
-        <translation>2秒隙間</translation>
+        <translation>2 秒の隙間</translation>
     </message>
     <message>
         <source>3 s Gap</source>
-        <translation>3秒隙間</translation>
+        <translation>3 秒の隙間</translation>
     </message>
     <message>
         <source>4 s Gap</source>
-        <translation>4秒隙間</translation>
+        <translation>4 秒の隙間</translation>
     </message>
     <message>
         <source>5 s Gap</source>
-        <translation>5秒隙間</translation>
+        <translation>5 秒の隙間</translation>
     </message>
 </context>
 <context>
@@ -3422,7 +3422,7 @@ Channel
     </message>
     <message>
         <source>MP3</source>
-        <translation></translation>
+        <translation>MP3</translation>
     </message>
     <message>
         <source>Use Variable Bit Rate Encoding (VBR)</source>
@@ -3430,23 +3430,23 @@ Channel
     </message>
     <message>
         <source>Quality:</source>
-        <translation>質:</translation>
+        <translation>音質:</translation>
     </message>
     <message>
         <source>RAW</source>
-        <translation></translation>
+        <translation>RAW</translation>
     </message>
     <message>
         <source>WAV</source>
-        <translation></translation>
+        <translation>WAV</translation>
     </message>
     <message>
         <source>Audio Format:</source>
-        <translation>オーディオフォーマット:</translation>
+        <translation>オーディオ形式:</translation>
     </message>
     <message>
         <source>CAF</source>
-        <translation></translation>
+        <translation>CAF</translation>
     </message>
     <message>
         <source>Lowest</source>
@@ -3458,7 +3458,7 @@ Channel
     </message>
     <message>
         <source>Medium Low</source>
-        <translation>中低</translation>
+        <translation>中-低</translation>
     </message>
     <message>
         <source>Medium</source>
@@ -3466,7 +3466,7 @@ Channel
     </message>
     <message>
         <source>Medium High</source>
-        <translation>中高</translation>
+        <translation>中-高</translation>
     </message>
     <message>
         <source>High</source>
@@ -3482,67 +3482,67 @@ Channel
     </message>
     <message>
         <source>16 kbps</source>
-        <translation></translation>
+        <translation>16 kbps</translation>
     </message>
     <message>
         <source>24 kbps</source>
-        <translation></translation>
+        <translation>24 kbps</translation>
     </message>
     <message>
         <source>32 kbps</source>
-        <translation></translation>
+        <translation>32 kbps</translation>
     </message>
     <message>
         <source>40 kbps</source>
-        <translation></translation>
+        <translation>40 kbps</translation>
     </message>
     <message>
         <source>48 kbps</source>
-        <translation></translation>
+        <translation>48 kbps</translation>
     </message>
     <message>
         <source>56 kbps</source>
-        <translation></translation>
+        <translation>56 kbps</translation>
     </message>
     <message>
         <source>64 kbps</source>
-        <translation></translation>
+        <translation>64 kbps</translation>
     </message>
     <message>
         <source>80 kbps</source>
-        <translation></translation>
+        <translation>80 kbps</translation>
     </message>
     <message>
         <source>96 kbps</source>
-        <translation></translation>
+        <translation>96 kbps</translation>
     </message>
     <message>
         <source>112 kbps</source>
-        <translation></translation>
+        <translation>112 kbps</translation>
     </message>
     <message>
         <source>128 kbps</source>
-        <translation></translation>
+        <translation>128 kbps</translation>
     </message>
     <message>
         <source>160 kbps</source>
-        <translation></translation>
+        <translation>160 kbps</translation>
     </message>
     <message>
         <source>192 kbps</source>
-        <translation></translation>
+        <translation>192 kbps</translation>
     </message>
     <message>
         <source>224 kbps</source>
-        <translation></translation>
+        <translation>224 kbps</translation>
     </message>
     <message>
         <source>256 kbps</source>
-        <translation></translation>
+        <translation>256 kbps</translation>
     </message>
     <message>
         <source>320 kbps</source>
-        <translation></translation>
+        <translation>320 kbps</translation>
     </message>
     <message>
         <source>Stereo Mode:</source>
@@ -3562,7 +3562,7 @@ Channel
     </message>
     <message>
         <source>Audio Compressor:</source>
-        <translation>オーディオ圧縮：</translation>
+        <translation>オーディオ圧縮機：</translation>
     </message>
     <message>
         <source>AAC - Advanced Audio Coding</source>
@@ -3570,7 +3570,7 @@ Channel
     </message>
     <message>
         <source>ALAC - Apple Lossless Audio Codec</source>
-        <translation>ALAC - Apple可逆オーディオ</translation>
+        <translation>ALAC - アップルの可逆圧縮方式のオーディオコーデック</translation>
     </message>
     <message>
         <source>Bit Rate:</source>
@@ -3582,7 +3582,7 @@ Channel
     </message>
     <message>
         <source>OGG</source>
-        <translation></translation>
+        <translation>OGG</translation>
     </message>
     <message>
         <source>Mode:</source>
@@ -3639,7 +3639,7 @@ Channel
     </message>
     <message>
         <source>Save each %1 to a separate file</source>
-        <translation>各　%1　を　別なファイルとして保存</translation>
+        <translation>各　%1 を別なファイルとして保存</translation>
     </message>
     <message>
         <source>Export Audio As</source>
@@ -3651,7 +3651,7 @@ Channel
     </message>
     <message>
         <source>“%1” already exists. Do you want to replace it?</source>
-        <translation>“%1”は既に既存しています。交換しますか？</translation>
+        <translation>“%1” は既に既存しています。交換しますか？</translation>
     </message>
     <message>
         <source>A audio file with the same name already exists in the selected folder. Replacing it will overwrite its current contents.</source>
@@ -3667,43 +3667,43 @@ Channel
     </message>
     <message>
         <source>Resolution:</source>
-        <translation type="unfinished"></translation>
+        <translation>レゾリューション</translation>
     </message>
     <message>
         <source>%1 bits</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 ビット</translation>
     </message>
     <message>
         <source>Dithering:</source>
-        <translation type="unfinished"></translation>
+        <translation>ディザリング:</translation>
     </message>
     <message>
         <source>Vorbis</source>
-        <translation type="unfinished"></translation>
+        <translation>Vorbis</translation>
     </message>
     <message>
         <source>Opus</source>
-        <translation type="unfinished"></translation>
+        <translation>Opus</translation>
     </message>
     <message>
         <source>%1</source>
-        <translation type="unfinished">%1</translation>
+        <translation>%1</translation>
     </message>
     <message>
         <source>Are you sure you want to use the “.%1” extension?</source>
-        <translation type="unfinished"></translation>
+        <translation>本当に“.%1” 拡張子を利用してよろしいですか？</translation>
     </message>
     <message>
         <source>The default extension for the selected format is “.%1”. If you choose a different extension, you might not be able to open the exported file.</source>
-        <translation type="unfinished"></translation>
+        <translation>選択された形式のデフォルト拡張子は“.%1” です。違う拡張子にしますと、書き出されたファイルを開く事が出来ない場合がございます。</translation>
     </message>
     <message>
         <source>Keep “.%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>“.%1” を保つ</translation>
     </message>
     <message>
         <source>Use “.%1” instead</source>
-        <translation type="unfinished"></translation>
+        <translation>代わりに “.%1” をしよう</translation>
     </message>
 </context>
 <context>
@@ -3829,7 +3829,7 @@ Channel
     </message>
     <message>
         <source>The file %1 already exists in the FTP server.</source>
-        <translation>ファイル　%1　が　既に　FTPサーバーに格納しています。</translation>
+        <translation>ファイル　%1 が　既に　FTPサーバーに格納しています。</translation>
     </message>
 </context>
 <context>
@@ -3910,39 +3910,39 @@ Channel
     </message>
     <message>
         <source>16000</source>
-        <translation></translation>
+        <translation>16000</translation>
     </message>
     <message>
         <source>Hz</source>
-        <translation></translation>
+        <translation>Hz</translation>
     </message>
     <message>
         <source>48000</source>
-        <translation></translation>
+        <translation>48000</translation>
     </message>
     <message>
         <source>44100</source>
-        <translation></translation>
+        <translation>44100</translation>
     </message>
     <message>
         <source>32000</source>
-        <translation></translation>
+        <translation>32000</translation>
     </message>
     <message>
         <source>22050</source>
-        <translation></translation>
+        <translation>22050</translation>
     </message>
     <message>
         <source>11025</source>
-        <translation></translation>
+        <translation>11025</translation>
     </message>
     <message>
         <source>8000</source>
-        <translation></translation>
+        <translation>8000</translation>
     </message>
     <message>
         <source>6000</source>
-        <translation></translation>
+        <translation>6000</translation>
     </message>
     <message>
         <source>Channels</source>
@@ -3978,11 +3978,11 @@ Channel
     </message>
     <message>
         <source>L</source>
-        <translation type="unfinished"></translation>
+        <translation>左</translation>
     </message>
     <message>
         <source>R</source>
-        <translation type="unfinished"></translation>
+        <translation>右</translation>
     </message>
 </context>
 <context>
@@ -4099,7 +4099,7 @@ Channel
     </message>
     <message>
         <source>100</source>
-        <translation></translation>
+        <translation>100</translation>
     </message>
     <message>
         <source>Invert</source>
@@ -4127,7 +4127,7 @@ Channel
     </message>
     <message>
         <source>Overlap (Mix)</source>
-        <translation>ミクサー</translation>
+        <translation>重なり合い（ミックス）</translation>
     </message>
     <message>
         <source>Replace</source>
@@ -4186,7 +4186,7 @@ Channel
     </message>
     <message>
         <source>Custom</source>
-        <translation type="unfinished"></translation>
+        <translation>カスタム</translation>
     </message>
     <message>
         <source>Channels</source>
@@ -4202,46 +4202,46 @@ Channel
     </message>
     <message>
         <source>Multichannel</source>
-        <translation type="unfinished"></translation>
+        <translation>マルチチャンネル</translation>
     </message>
     <message>
         <source>3 channels</source>
-        <translation type="unfinished"></translation>
+        <translation>3 チャンネル</translation>
     </message>
     <message>
         <source>4 channels</source>
-        <translation type="unfinished"></translation>
+        <translation>4 チャンネル</translation>
     </message>
     <message>
         <source>5 channels</source>
-        <translation type="unfinished"></translation>
+        <translation>5 チャンネル</translation>
     </message>
     <message>
         <source>6 channels</source>
-        <translation type="unfinished"></translation>
+        <translation>6 チャンネル</translation>
     </message>
     <message>
         <source>7 channels</source>
-        <translation type="unfinished"></translation>
+        <translation>7 チャンネル</translation>
     </message>
     <message>
         <source>8 channels</source>
-        <translation type="unfinished"></translation>
+        <translation>8 チャンネル</translation>
     </message>
     <message>
         <source>44100 Hz</source>
-        <translation></translation>
+        <translation>44100 Hz</translation>
     </message>
     <message>
         <source>48000 Hz</source>
-        <translation></translation>
+        <translation>48000 Hz</translation>
     </message>
 </context>
 <context>
     <name>QOcenNewAudioDialog::Data</name>
     <message>
         <source>Custom</source>
-        <translation type="unfinished"></translation>
+        <translation>カスタム</translation>
     </message>
 </context>
 <context>
@@ -4268,84 +4268,84 @@ Channel
     </message>
     <message>
         <source>Open both files in this %1</source>
-        <translation>%1　に両方のファイルを開く</translation>
+        <translation>%1 に両方のファイルを開く</translation>
     </message>
     <message>
         <source>Open all %1 files in this %2</source>
-        <translation>この　%2　に全ての　%1　ファイルを開く</translation>
+        <translation>この　%2 に全ての　%1 ファイルを開く</translation>
     </message>
     <message>
         <source>and %1 other files</source>
-        <translation>それに　%1　他のファイル</translation>
+        <translation>それに　%1 他のファイル</translation>
     </message>
 </context>
 <context>
     <name>QOcenSoundMixerConfigDialog</name>
     <message>
         <source>Sound Mixer Configuration</source>
-        <translation type="unfinished"></translation>
+        <translation>音ミクサーの設定</translation>
     </message>
     <message>
         <source>Playback</source>
-        <translation type="unfinished"></translation>
+        <translation>再生する</translation>
     </message>
     <message>
         <source>1 Channel (Mono)</source>
-        <translation type="unfinished"></translation>
+        <translation>1 チャンネル　（モノラル）</translation>
     </message>
     <message>
         <source> ➨ </source>
-        <translation type="unfinished"></translation>
+        <translation> ➨ </translation>
     </message>
     <message>
         <source>Built-In Output (2 Channels)</source>
-        <translation type="unfinished"></translation>
+        <translation>組み込みアウトプット（2 チャンネル）</translation>
     </message>
     <message>
         <source>Built-In Input (2 Channels)</source>
-        <translation type="unfinished"></translation>
+        <translation>組み込みインプット（2 チャンネル）</translation>
     </message>
     <message>
         <source>1 channel (mono)</source>
-        <translation type="unfinished"></translation>
+        <translation>1 チャンネル　（モノラル）</translation>
     </message>
     <message>
         <source>2 channels (stereo)</source>
-        <translation type="unfinished"></translation>
+        <translation>2 チャンネル　（ステレオ）</translation>
     </message>
     <message>
         <source>%1 channels</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 チャンネル</translation>
     </message>
     <message>
         <source>Input #%1 </source>
-        <translation type="unfinished"></translation>
+        <translation>インプット</translation>
     </message>
     <message>
         <source>Channel
 #%1</source>
-        <translation type="unfinished"></translation>
+        <translation>チャンネル</translation>
     </message>
     <message>
         <source>Channel #%1 </source>
-        <translation type="unfinished"></translation>
+        <translation>チャンネル #%1</translation>
     </message>
     <message>
         <source>Output
 #%1</source>
-        <translation type="unfinished"></translation>
+        <translation>アウトプット</translation>
     </message>
     <message>
         <source>No recording devices found!</source>
-        <translation type="unfinished"></translation>
+        <translation>録音デバイスが見つかりません</translation>
     </message>
     <message>
         <source>No playback devices found!</source>
-        <translation type="unfinished"></translation>
+        <translation>再生デバイスが見つかりません</translation>
     </message>
     <message>
         <source>Record</source>
-        <translation type="unfinished">録音</translation>
+        <translation>録音</translation>
     </message>
 </context>
 <context>
@@ -4368,7 +4368,7 @@ or your network that you want to open:</source>
     </message>
     <message>
         <source>Applying %1|%1</source>
-        <translation>%1|%1適用中</translation>
+        <translation>%1|%1 適用中</translation>
     </message>
     <message>
         <source>Plugin crashed</source>
@@ -4376,11 +4376,11 @@ or your network that you want to open:</source>
     </message>
     <message>
         <source>The plugin %1 crashed and will be finalized.</source>
-        <translation>プラグイン%1が落ちたので、終了させられます。</translation>
+        <translation>プラグイン%1 が落ちたので、終了させられます。</translation>
     </message>
     <message>
-        <source>Ocenaudio was not affected by this crash and will continue running normally.</source>
-        <translation>オセンオーディオがこの失敗に影響されていないので、正常に稼働し続けます。</translation>
+        <source>ocenaudio was not affected by this crash and will continue running normally.</source>
+        <translation>ocenaudioがこのクラッシュに影響されていないので、正常にご利用し続ける事が可能です。</translation>
     </message>
     <message>
         <source>VST Effect:</source>
@@ -4419,7 +4419,7 @@ or your network that you want to open:</source>
     </message>
     <message>
         <source>Effects in Folder %1</source>
-        <translation>フォルダー　%1　のエフェクト</translation>
+        <translation>フォルダー　%1 のエフェクト</translation>
     </message>
     <message>
         <source>Crashed</source>
@@ -4458,43 +4458,43 @@ or your network that you want to open:</source>
     </message>
     <message>
         <source>Show in Finder</source>
-        <translation type="unfinished"></translation>
+        <translation>ファインダーで表示する</translation>
     </message>
     <message>
         <source>Show Plugins List...</source>
-        <translation type="unfinished"></translation>
+        <translation>プラグインリストを表示...</translation>
     </message>
     <message>
         <source>Remove Path from Search</source>
-        <translation type="unfinished"></translation>
+        <translation>検索からパスを外す</translation>
     </message>
     <message>
         <source>Path not Found</source>
-        <translation type="unfinished"></translation>
+        <translation>パスは見つかりません</translation>
     </message>
     <message>
         <source>Add VST Path</source>
-        <translation type="unfinished"></translation>
+        <translation>VSTのパスを追加する</translation>
     </message>
     <message>
         <source>Add a new path to search for VST effects</source>
-        <translation type="unfinished"></translation>
+        <translation>VSTエフェクトを検するには新しいパスを追加する</translation>
     </message>
     <message>
         <source>Remove VST Path</source>
-        <translation type="unfinished"></translation>
+        <translation>VSTのパスを外す</translation>
     </message>
     <message>
         <source>Remove path from VST path list</source>
-        <translation type="unfinished"></translation>
+        <translation>パスリストからVSTのパスを外す</translation>
     </message>
     <message>
         <source>Refresh VST Effects</source>
-        <translation type="unfinished"></translation>
+        <translation>VSTエフェクトをリフレッシュ</translation>
     </message>
     <message>
         <source>Search for VST effects in the selected path</source>
-        <translation type="unfinished"></translation>
+        <translation>選択したパスにてVSTエフェクトを検索する</translation>
     </message>
 </context>
 <context>
@@ -4533,7 +4533,7 @@ or your network that you want to open:</source>
     </message>
     <message>
         <source>Extract Channel %1</source>
-        <translation>チャンネル%1を引き抜く</translation>
+        <translation>チャンネル%1 を抜き取る</translation>
     </message>
     <message>
         <source>Downmix to a Stereo File</source>
@@ -4541,7 +4541,7 @@ or your network that you want to open:</source>
     </message>
     <message>
         <source>Downmix to a Quadraphonic File</source>
-        <translation>4チャンネル方式にダウンミックス</translation>
+        <translation>4 チャンネルステレオファイルにダウンミックス</translation>
     </message>
     <message>
         <source>Get Info</source>
@@ -4577,11 +4577,11 @@ or your network that you want to open:</source>
     </message>
     <message>
         <source>Repeat %1 in Selected Files</source>
-        <translation>選択されたファイルに　%1　を付ける</translation>
+        <translation>選択されたファイルに　%1 を付ける</translation>
     </message>
     <message>
         <source>Extract %1 Channel</source>
-        <translation>%1　チャンネルを引き抜く</translation>
+        <translation>%1 チャンネルを抜き取る</translation>
     </message>
     <message>
         <source>Stop</source>
@@ -4617,7 +4617,7 @@ or your network that you want to open:</source>
     </message>
     <message>
         <source>You are about to append %1 files in the selected audio. Are you sure you want to proceed?</source>
-        <translation>選択されたファイルに　%1　を加えます。宜しいですか？</translation>
+        <translation>選択されたファイルに　%1 のファイルを加えます。宜しいですか？</translation>
     </message>
     <message>
         <source>This operation may take a long time.</source>
@@ -4653,47 +4653,47 @@ or your network that you want to open:</source>
     </message>
     <message>
         <source>Convert to Mono</source>
-        <translation type="unfinished"></translation>
+        <translation>モノラルに変換する</translation>
     </message>
     <message>
         <source>Sort</source>
-        <translation type="unfinished"></translation>
+        <translation>並び替え</translation>
     </message>
     <message>
         <source>Disabled</source>
-        <translation type="unfinished"></translation>
+        <translation>無効</translation>
     </message>
     <message>
         <source>By Display Name</source>
-        <translation type="unfinished"></translation>
+        <translation>表示名で</translation>
     </message>
     <message>
         <source>By Song Name</source>
-        <translation type="unfinished"></translation>
+        <translation>曲名で</translation>
     </message>
     <message>
         <source>By Artist Name</source>
-        <translation type="unfinished"></translation>
+        <translation>アーティスト名で</translation>
     </message>
     <message>
         <source>By Album Name</source>
-        <translation type="unfinished"></translation>
+        <translation>アルバム名</translation>
     </message>
     <message>
         <source>By Duration</source>
-        <translation type="unfinished"></translation>
+        <translation>長さで</translation>
     </message>
     <message>
         <source>By Date</source>
-        <translation type="unfinished"></translation>
+        <translation>日時で</translation>
     </message>
     <message>
         <source>Ascending</source>
-        <translation type="unfinished"></translation>
+        <translation>昇順</translation>
     </message>
     <message>
         <source>Descending</source>
-        <translation type="unfinished"></translation>
+        <translation>降順</translation>
     </message>
 </context>
 <context>
@@ -4704,7 +4704,7 @@ or your network that you want to open:</source>
     </message>
     <message>
         <source>Noise</source>
-        <translation>雑音</translation>
+        <translation>ノイズ</translation>
     </message>
     <message>
         <source>Color</source>
@@ -4756,7 +4756,7 @@ or your network that you want to open:</source>
     </message>
     <message>
         <source>Hz</source>
-        <translation></translation>
+        <translation>Hz</translation>
     </message>
     <message>
         <source>End</source>
@@ -4940,11 +4940,11 @@ or your network that you want to open:</source>
     </message>
     <message>
         <source>Generating %1 Noise</source>
-        <translation>%1　雑音を生成</translation>
+        <translation>%1 ノイズを生成</translation>
     </message>
     <message>
         <source>%1 Noise Generation</source>
-        <translation>%1　の雑音生成</translation>
+        <translation>%1 ノイズ生成</translation>
     </message>
     <message>
         <source>Generating %1 Tone</source>
@@ -4952,7 +4952,7 @@ or your network that you want to open:</source>
     </message>
     <message>
         <source>%1 Tone Generation</source>
-        <translation>%1　の音色生成</translation>
+        <translation>%1 の音色生成</translation>
     </message>
     <message>
         <source>Generating DTMF</source>
@@ -5078,27 +5078,27 @@ or your network that you want to open:</source>
     </message>
     <message>
         <source>Use this configuration for next files having extension &apos;.%1&apos;</source>
-        <translation>&apos;.%1&apos;とのエクステンションのファイルに、この設定を利用する</translation>
+        <translation>&apos;.%1&apos;拡張子のファイルに、この設定を利用する</translation>
     </message>
     <message>
         <source>Use this configuration for next files having no extension</source>
-        <translation>エクステンションのないファイルに、この設定を利用する</translation>
+        <translation>拡張子のないファイルに、この設定を利用する</translation>
     </message>
     <message>
         <source>3 channels</source>
-        <translation type="unfinished"></translation>
+        <translation>3 チャンネル</translation>
     </message>
     <message>
         <source>4 channels</source>
-        <translation type="unfinished"></translation>
+        <translation>4 チャンネル</translation>
     </message>
     <message>
         <source>5 channels</source>
-        <translation type="unfinished"></translation>
+        <translation>5 チャンネル</translation>
     </message>
     <message>
         <source>6 channels</source>
-        <translation type="unfinished"></translation>
+        <translation>6 チャンネル</translation>
     </message>
 </context>
 <context>
@@ -5348,7 +5348,7 @@ or your network that you want to open:</source>
     </message>
     <message>
         <source>High Dpi Image</source>
-        <translation type="unfinished"></translation>
+        <translation>ドット密度の高い映像</translation>
     </message>
 </context>
 </TS>

--- a/ja_JP/qtocen_ja_JP.ts
+++ b/ja_JP/qtocen_ja_JP.ts
@@ -136,7 +136,7 @@
     </message>
     <message>
         <source>Ringtone created by ocenaudio</source>
-        <translation>オセンオーディオに着メロ作成されました</translation>
+        <translation>Ocenaudioに着メロ作成されました</translation>
     </message>
     <message>
         <source>Creating iTunes Ringtone</source>
@@ -220,43 +220,43 @@
     </message>
     <message>
         <source>0</source>
-        <translation>100% {0?}</translation>
+        <translation>0</translation>
     </message>
     <message>
         <source>L</source>
-        <translation type="unfinished"></translation>
+        <translation>左</translation>
     </message>
     <message>
         <source>R</source>
-        <translation type="unfinished"></translation>
+        <translation>右</translation>
     </message>
     <message>
         <source>%1 channel of</source>
-        <translation>%1　のチャンネル</translation>
+        <translation>%1 のチャンネル</translation>
     </message>
     <message>
         <source>%1 combined with %2</source>
-        <translation>%1 を　%2　に合体</translation>
+        <translation>%1 を　%2 に合体</translation>
     </message>
     <message>
         <source>Downmix of %1</source>
-        <translation>%1　のダウンミックス</translation>
+        <translation>%1 のダウンミックス</translation>
     </message>
     <message>
         <source>Join of %1 and %2</source>
-        <translation>%1 、　%2　の結合</translation>
+        <translation>%1 、　%2 の結合</translation>
     </message>
     <message>
         <source>Join of %1, %2 and %3</source>
-        <translation>%1　、 %2　、　%3　の結合</translation>
+        <translation>%1　、 %2　、　%3 の結合</translation>
     </message>
     <message>
         <source>Join of %1, %2 and other %3 files</source>
-        <translation>%1　、 %2　、　他の　%3　ファイル　の結合</translation>
+        <translation>%1 ・ %2 ・ 他の　%3 ファイル　を結合する</translation>
     </message>
     <message>
         <source>Reversing</source>
-        <translation>逆にしています</translation>
+        <translation>逆にしている</translation>
     </message>
     <message>
         <source>Reverse</source>
@@ -264,7 +264,7 @@
     </message>
     <message>
         <source>Inverting</source>
-        <translation>転倒しています</translation>
+        <translation>転倒している</translation>
     </message>
     <message>
         <source>Invert</source>
@@ -340,27 +340,27 @@
     </message>
     <message>
         <source>Export As</source>
-        <translation>「x」として書き出す</translation>
+        <translation>としてエクスポート</translation>
     </message>
     <message>
         <source>Exporting Selection As</source>
-        <translation>選択を書き出す</translation>
+        <translation>選択をエクスポート中</translation>
     </message>
     <message>
         <source>Exporting Region As</source>
-        <translation>領域を「x」として書き出す</translation>
+        <translation>領域をエクスポート中</translation>
     </message>
     <message>
         <source>Exporting Regions As</source>
-        <translation>複数な領域を「x」として書き出す</translation>
+        <translation>領域をエクスポート中</translation>
     </message>
     <message>
         <source>Paste Channel</source>
-        <translation type="unfinished"></translation>
+        <translation>チャンネルを張り付ける</translation>
     </message>
     <message>
         <source>Paste From File</source>
-        <translation type="unfinished"></translation>
+        <translation>ファイルから張り付ける</translation>
     </message>
     <message>
         <source>Paste Silence</source>
@@ -428,99 +428,99 @@
     </message>
     <message>
         <source>Transform</source>
-        <translation type="unfinished"></translation>
+        <translation>トランスフォーム</translation>
     </message>
     <message>
         <source>Change Gain/Offset</source>
-        <translation type="unfinished"></translation>
+        <translation>増幅を変更する</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished">取り消す</translation>
+        <translation type>取り消す</translation>
     </message>
     <message>
         <source>Waiting for cancellation</source>
-        <translation type="unfinished"></translation>
+        <translation>取消すのを待機中</translation>
     </message>
     <message>
         <source>Remaining</source>
-        <translation type="unfinished"></translation>
+        <translation>残り</translation>
     </message>
     <message>
         <source>Question</source>
-        <translation type="unfinished">質問</translation>
+        <translation>質問</translation>
     </message>
     <message>
         <source>Do you really want to discard the changes made in this region?</source>
-        <translation type="unfinished">この領域の変更を削除してよろしいですか?</translation>
+        <translation>この領域の変更を削除してよろしいですか?</translation>
     </message>
     <message>
         <source>Changes in region text will be lost if you discard.</source>
-        <translation type="unfinished">処分すると、領域テキストの変更が失われます。</translation>
+        <translation>処分しますと、領域テキストの変更が失われます。</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished">保存</translation>
+        <translation>保存</translation>
     </message>
     <message>
         <source>Discard</source>
-        <translation type="unfinished">処分する</translation>
+        <translation>処分する</translation>
     </message>
     <message>
         <source>Track %1</source>
-        <translation type="unfinished"></translation>
+        <translation>トラック %1</translation>
     </message>
     <message>
         <source>@%1 (unlinked)</source>
-        <translation type="unfinished"></translation>
+        <translation>@%1 （アンリンク済）</translation>
     </message>
     <message>
         <source>Smooth</source>
-        <translation type="unfinished"></translation>
+        <translation>和らげる</translation>
     </message>
     <message>
         <source>General</source>
-        <translation type="unfinished">一般</translation>
+        <translation>一般</translation>
     </message>
     <message>
         <source>General Preferences</source>
-        <translation type="unfinished"></translation>
+        <translation>一般設定</translation>
     </message>
     <message>
         <source>Key Bindings</source>
-        <translation type="unfinished">キー機能設定</translation>
+        <translation>キーバインド</translation>
     </message>
     <message>
         <source>Key Bindings Preferences</source>
-        <translation type="unfinished"></translation>
+        <translation>キーバインド設定</translation>
     </message>
     <message>
         <source>Network</source>
-        <translation type="unfinished">ネットワーク</translation>
+        <translation>ネットワーク</translation>
     </message>
     <message>
         <source>Network Preferences</source>
-        <translation type="unfinished"></translation>
+        <translation>ネットワーク設定</translation>
     </message>
     <message>
         <source>Supported Sound Files</source>
-        <translation type="unfinished"></translation>
+        <translation>対応の音形式</translation>
     </message>
     <message>
         <source>Sound</source>
-        <translation type="unfinished"></translation>
+        <translation>音</translation>
     </message>
     <message>
         <source>Sound Preferences</source>
-        <translation type="unfinished"></translation>
+        <translation>音設定</translation>
     </message>
     <message>
         <source>Spectrogram</source>
-        <translation type="unfinished">分光映像</translation>
+        <translation>スペクトルグラム</translation>
     </message>
     <message>
         <source>Spectogram Preferences</source>
-        <translation type="unfinished"></translation>
+        <translation>スペクトルグラムの設定</translation>
     </message>
 </context>
 <context>
@@ -531,7 +531,7 @@
     </message>
     <message>
         <source>ocenaudio Clipboard with %1 seconds in %2 %3</source>
-        <translation type="unfinished"></translation>
+        <translation>Ocenaudioのクリップボードにて %2 %3 で %1 秒</translation>
     </message>
 </context>
 <context>
@@ -613,7 +613,7 @@
     </message>
     <message>
         <source>readonly</source>
-        <translation type="unfinished"></translation>
+        <translation>読み出し専用</translation>
     </message>
 </context>
 <context>
@@ -639,35 +639,35 @@
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished">取り消す</translation>
+        <translation>取り消す</translation>
     </message>
     <message>
         <source>Close</source>
-        <translation type="unfinished">閉じる</translation>
+        <translation>閉じる</translation>
     </message>
     <message>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>再生</translation>
     </message>
     <message>
         <source>Stop</source>
-        <translation type="unfinished"></translation>
+        <translation>中止</translation>
     </message>
     <message>
         <source>Link the view state of this audio to the current visible audio</source>
-        <translation type="unfinished"></translation>
+        <translation>現在表示されてるオーディオに　このオーディオの表示状態をリンクする</translation>
     </message>
     <message>
         <source>Unlink the view state of this audio</source>
-        <translation type="unfinished"></translation>
+        <translation>このオーディオから表示状態をアンリンクする</translation>
     </message>
     <message>
         <source>Link the view state of this audio to others linked audios (if any)</source>
-        <translation type="unfinished"></translation>
+        <translation>リンク済オーディオがある場合、このオーディオの表示状態にリンクする</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished">保存</translation>
+        <translation>保存</translation>
     </message>
 </context>
 <context>
@@ -742,43 +742,43 @@
     </message>
     <message>
         <source>Color Scheme</source>
-        <translation type="unfinished"></translation>
+        <translation>配色</translation>
     </message>
     <message>
         <source>Classic</source>
-        <translation type="unfinished"></translation>
+        <translation>クラシック</translation>
     </message>
     <message>
         <source>Light</source>
-        <translation type="unfinished"></translation>
+        <translation>明るい</translation>
     </message>
     <message>
         <source>Dark</source>
-        <translation type="unfinished"></translation>
+        <translation>暗い</translation>
     </message>
     <message>
         <source>Select ocenaudio interface language</source>
-        <translation type="unfinished"></translation>
+        <translation>Ocenaudioのインターフェース言語を選択</translation>
     </message>
     <message>
         <source>Select color scheme to be used in ocenaudio interface</source>
-        <translation type="unfinished"></translation>
+        <translation>Ocenaudioのインターフェース配色を選択</translation>
     </message>
     <message>
         <source>Smooth Cut and Delete boundaries</source>
-        <translation type="unfinished"></translation>
+        <translation>限度を和らげて　切り取って削除する</translation>
     </message>
     <message>
         <source>Keep a backup copy of original file before overwrite</source>
-        <translation type="unfinished"></translation>
+        <translation>上書きする前に、元のファイルをバックアップする</translation>
     </message>
     <message>
         <source>System Language (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>システム言語 (%1)</translation>
     </message>
     <message>
         <source>Aqua</source>
-        <translation type="unfinished"></translation>
+        <translation>アクア</translation>
     </message>
 </context>
 <context>
@@ -827,23 +827,23 @@
     </message>
     <message>
         <source>Key binding action list</source>
-        <translation type="unfinished"></translation>
+        <translation>キーバインド行動リスト</translation>
     </message>
     <message>
         <source>List of ocenaudio actions and theirs key bindings</source>
-        <translation type="unfinished"></translation>
+        <translation>キーバインドと該当行動のリスト</translation>
     </message>
     <message>
         <source>Key bindings action filter</source>
-        <translation type="unfinished"></translation>
+        <translation>キーバインド行動フィルター</translation>
     </message>
     <message>
         <source>Filter the key bindings action list</source>
-        <translation type="unfinished"></translation>
+        <translation>キーバインド行動リストをフィルターする</translation>
     </message>
     <message>
         <source>Filter</source>
-        <translation type="unfinished"></translation>
+        <translation>フィルター</translation>
     </message>
 </context>
 <context>
@@ -925,7 +925,7 @@
     </message>
     <message>
         <source>Keep ocenaudio Version</source>
-        <translation>オセンオーディオのバージョンをキープ</translation>
+        <translation>このOcenaudioのバージョンを取っておく</translation>
     </message>
     <message>
         <source>Revert</source>
@@ -997,123 +997,123 @@
     </message>
     <message>
         <source>This is an unrecoverable error and ocenaudio must quit. This issue might happen if your main disk is running out of free space.</source>
-        <translation>回復出来ないエラーの為、オセンオーディオが終了しなければなりません。ディスクの領域が不足が原因可能性があります。</translation>
+        <translation>回復出来ないエラーの為、Ocenaudioが終了しなければなりません。ディスクの領域が不足が原因可能性があります。</translation>
     </message>
     <message>
         <source>Your changes will be lost if you don’t save them.</source>
-        <translation type="unfinished"></translation>
+        <translation>保存しないと変更が失われます。</translation>
     </message>
     <message>
         <source>An error occured while writing temporary data to disk!</source>
-        <translation type="unfinished"></translation>
+        <translation>仮データをディスクに書き込もうとして、エラーが発生されました。</translation>
     </message>
     <message>
         <source>Information</source>
-        <translation type="unfinished"></translation>
+        <translation>情報</translation>
     </message>
     <message>
         <source>Pasting file %1</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 ファイルを貼り付けています</translation>
     </message>
     <message>
         <source>Unsupported Format</source>
-        <translation type="unfinished"></translation>
+        <translation>非対応の形式</translation>
     </message>
     <message>
         <source>The maximum number of channels supported is %1 channels.</source>
-        <translation type="unfinished"></translation>
+        <translation>可能な最大限チャンネル数は %1</translation>
     </message>
     <message>
         <source>The minimum sample rate supported is %1 Hz.</source>
-        <translation type="unfinished"></translation>
+        <translation>可能な最低限サンプルレートは %1 Hz。</translation>
     </message>
     <message>
         <source>The maximum sample rate supported is %1 Hz.</source>
-        <translation type="unfinished"></translation>
+        <translation>可能な最大限のサンプルレートは %1 Hz。</translation>
     </message>
     <message>
         <source>Audio VST Check Failed</source>
-        <translation type="unfinished"></translation>
+        <translation>オーディオVSTチェック失敗しました</translation>
     </message>
     <message>
         <source>An error occurred in the execution of VST plugin application. No VST plugin can be loaded in this condition.</source>
-        <translation type="unfinished"></translation>
+        <translation>VSTプラグインを適用した時にエラーが発生されました。この状態でVSTプラグイン読み込みは不可能です。</translation>
     </message>
     <message>
         <source>Audio not saved</source>
-        <translation type="unfinished"></translation>
+        <translation>オーディオは保存されていません</translation>
     </message>
     <message>
         <source>An error was encountered while saving your sound file “%1”!</source>
-        <translation type="unfinished"></translation>
+        <translation>“%1” サウンドファイルを保存しようとした時にエラーが発生されました！</translation>
     </message>
     <message>
         <source>It was not possible to complete the save of file “%1” because the chosen container does not support metadata.</source>
-        <translation type="unfinished"></translation>
+        <translation>選択されたコンテーナーがmetadataを対応していない為、“%1” ファイルを保存できませんでした。</translation>
     </message>
     <message>
         <source>Your sound “%1” contains informations that can not be saved in the selected format. You want to continue and export to this format?</source>
-        <translation type="unfinished"></translation>
+        <translation>選択された形式が</translation>
     </message>
     <message>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>エクスポート</translation>
     </message>
     <message>
         <source>Exporting As</source>
-        <translation type="unfinished"></translation>
+        <translation>としてエクスポート</translation>
     </message>
     <message>
         <source>Unsupported information will not be present in the exported file.</source>
-        <translation type="unfinished"></translation>
+        <translation>エクスポートされたファイルに非対応情報は含まれません。</translation>
     </message>
     <message>
         <source>The file for the sound that was at %1 is now empty. Do you want to keep as new, save or close the sound?</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 にあるサウンドのファイルは空になっています。サウンドを新しいままで取っておくか、保存するか、閉じますか？</translation>
     </message>
     <message>
         <source>The file for the sound that was at %1 is now corrupted. Do you want to keep as new, save or close the sound?</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 にあるサウンドのファイルは破壊されています。サウンドを新しいままで取っておくか、保存するか、閉じますか？</translation>
     </message>
     <message>
         <source>Keep as New</source>
-        <translation type="unfinished"></translation>
+        <translation>新しいままで取っておく</translation>
     </message>
     <message>
         <source>The file for the sound that was at %1 has disappeared. The document has previously unsaved changes. Do you want to keep as new, save or close the sound?</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 にあるサウンドのファイルが見つかりません。以前に保存されていない変更が含まれています。サウンドを新しいままで取っておくか、保存するか、閉じますか？</translation>
     </message>
     <message>
         <source>Would you like to proceed and reencode the audio?</source>
-        <translation type="unfinished"></translation>
+        <translation>オーディオを再エンコードしますか？</translation>
     </message>
     <message>
         <source>Your changes affect only the metadata, however ocenaudio don&apos;t supports metadata update for this format. If you proceed, a complete rewrite of your file will be done (this may re-encode your audio signal).</source>
-        <translation type="unfinished"></translation>
+        <translation>この形式のmetadataを更新する事は不可能です。metadataのみの変更がある為、続行しますとファイルが完全に作り直されます。（オーディオの信号を再エンコードする場合があります。）</translation>
     </message>
     <message>
         <source>The file for the sound at %1 has been modified by another application. There are also unsaved changes in ocenaudio. Do you want to keep the ocenaudio version or revert to the version on disk?</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 にあるサウンドのファイルが違うアプリケーションに変更されました。ocenaudioにて保全されていない変更もあります。ocenaudioのバージョンを利用するかディスクのバージョンを利用しますか？</translation>
     </message>
     <message>
         <source>The file for the sound that was at %1 has disappeared. Do you want to keep as new, save or close the sound?</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 にあるサウンドのファイルが見つかりません。サウンドを新しいままで取っておくか、保存するか、閉じますか？</translation>
     </message>
     <message>
         <source>Supported Sound Files</source>
-        <translation type="unfinished"></translation>
+        <translation>対応可能サウンドファイル</translation>
     </message>
     <message>
         <source>Do you want to overwrite the backup copy of the original file?</source>
-        <translation type="unfinished"></translation>
+        <translation>元のファイルのバックアップを上書きしますか？</translation>
     </message>
     <message>
         <source>The file “%1” already has a backup. If you proceed it will be replaced by the current version of this file.</source>
-        <translation type="unfinished"></translation>
+        <translation>“%1” のファイルにバックアップがあります。続行しますとこのファイルの現在バージョンに上書きされます。</translation>
     </message>
     <message>
         <source>readonly</source>
-        <translation type="unfinished"></translation>
+        <translation>読み出し専用</translation>
     </message>
 </context>
 <context>
@@ -1190,7 +1190,7 @@
     </message>
     <message>
         <source>Keep ocenaudio Version</source>
-        <translation>オセンオーディオのバージョンをキープ</translation>
+        <translation>Ocenaudioのバージョンを変更しない</translation>
     </message>
     <message>
         <source>Revert</source>
@@ -1198,11 +1198,11 @@
     </message>
     <message>
         <source>File not found.</source>
-        <translation>ファイルは見つかられていません。</translation>
+        <translation>ファイルは見つかりません。</translation>
     </message>
     <message>
         <source>The file that was at %1 no longer exists.</source>
-        <translation>%1　にあったファイルはもう存在していません。</translation>
+        <translation>%1 にあったファイルはもう存在していません。</translation>
     </message>
     <message>
         <source>Ok</source>
@@ -1234,43 +1234,43 @@
     </message>
     <message>
         <source>The file “%1” was not found. Check if your filename is valid and you have permission to open it.</source>
-        <translation>“%1”ファイルはみつかっていません。 ファイル名が正しいか、 開くのに許可を得ている事を確認して下さい。</translation>
+        <translation>“%1” ファイルはみつかっていません。 ファイル名が正しいか、 開くのに許可を得ている事を確認して下さい。</translation>
     </message>
     <message>
         <source>An error occurred while trying to open the file “%1”.</source>
-        <translation type="unfinished"></translation>
+        <translation>“%1” にあるファイルを開こうとしたがエラーが発生されました。</translation>
     </message>
     <message>
         <source>Check if your file have an incorrect or unsuported format.</source>
-        <translation type="unfinished"></translation>
+        <translation>ファイルの形式が正しくないか、非対応かご確認下さい。</translation>
     </message>
     <message>
         <source>Analyzing files in %1 %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 %2 のファイルを分析中</translation>
     </message>
     <message>
         <source>Analyzing files in %1</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 のファイルを分析中</translation>
     </message>
     <message>
         <source>The file for the sound at “%1” is already opened. There are also unsaved changes in ocenaudio.  Do you want to keep the ocenaudio version or revert to the version on disk?</source>
-        <translation type="unfinished"></translation>
+        <translation>サウンド “%1” のファイルは既に開いています。ocenaudioにて保全されていない変更もあります。ocenaudioのバージョンを利用するかディスクのバージョンを利用しますか？</translation>
     </message>
     <message>
         <source>Cue File Found</source>
-        <translation type="unfinished"></translation>
+        <translation<キューファイル見つかりました。/translation>
     </message>
     <message>
         <source>A cue file containing %2 tracks associated with the “%1” file was found. You want to open these tracks separately?</source>
-        <translation type="unfinished"></translation>
+        <translation>“%1” ファイルに %2 トラック入ってるキューファイルが見つかりました。トラックを別々開きますか？</translation>
     </message>
     <message>
         <source>Open Tracks</source>
-        <translation type="unfinished"></translation>
+        <translation>トラックを開く</translation>
     </message>
     <message>
         <source>Open Original</source>
-        <translation type="unfinished"></translation>
+        <translation>元のを開く</translation>
     </message>
 </context>
 <context>
@@ -1289,11 +1289,11 @@
     </message>
     <message>
         <source>The plugin &quot;%1&quot; is not compatible with your ocenaudio version.</source>
-        <translation>&quot;%1&quot;のプラグインはこのオセンオーディオのバージョンに対応していません。</translation>
+        <translation>&quot;%1&quot;のプラグインはこのOcenaudioのバージョンに対応していません。</translation>
     </message>
     <message>
         <source>To proceed with the installation it is necessary to first update ocenaudio.</source>
-        <translation>インストールするために、オセンオーディオを更新する必要があります。</translation>
+        <translation>インストールするために、Ocenaudioを更新する必要があります。</translation>
     </message>
     <message>
         <source>Question</source>
@@ -1305,7 +1305,7 @@
     </message>
     <message>
         <source>If you proceed ocenaudio will check the integrity, install and load the selected plugin package.</source>
-        <translation>進めると、オセンオーディオが整合性を確認した上、インストールしてから選択されたプラグインパッケージをロードします。</translation>
+        <translation>進めると、Ocenaudioが整合性を確認した上、インストールしてから選択されたプラグインパッケージをロードします。</translation>
     </message>
     <message>
         <source>Error</source>
@@ -1325,7 +1325,7 @@
     </message>
     <message>
         <source>One or more errors were detected during the installation process. You can try again and if the error persists contact the ocenaudio team.</source>
-        <translation>インストール中に　１以上のエラーが検出されました。再インストールしてみてください。問題が解決しない場合、オセンオーディオチームにご連絡下さい。</translation>
+        <translation>インストール中に　１以上のエラーが検出されました。再インストールしてみてください。問題が解決しない場合、Ocenaudioチームにご連絡下さい。</translation>
     </message>
     <message>
         <source>Invalid Plugin Code Signature</source>
@@ -1355,14 +1355,14 @@
     <name>QOcenPreferences</name>
     <message>
         <source>Settings</source>
-        <translation type="unfinished">設定</translation>
+        <translation>設定</translation>
     </message>
 </context>
 <context>
     <name>QOcenQuickOpenWidget</name>
     <message>
         <source>File or http address</source>
-        <translation type="unfinished"></translation>
+        <translation>ファイル又はhttpアドレス</translation>
     </message>
 </context>
 <context>
@@ -1388,11 +1388,11 @@
     <name>QOcenSettingsDialog</name>
     <message>
         <source>Settings</source>
-        <translation type="unfinished">設定</translation>
+        <translation>設定</translation>
     </message>
     <message>
         <source>Search</source>
-        <translation type="unfinished"></translation>
+        <translation>検索</translation>
     </message>
 </context>
 <context>
@@ -1419,7 +1419,7 @@
     </message>
     <message>
         <source>Mixer Sample Rate</source>
-        <translation type="unfinished"></translation>
+        <translation>ミクサーサンプルレート</translation>
     </message>
     <message>
         <source>48000 Hz</source>
@@ -1435,15 +1435,15 @@
     </message>
     <message>
         <source>Mixer Backend</source>
-        <translation type="unfinished"></translation>
+        <translation>ミキサーバックエンド</translation>
     </message>
     <message>
         <source>CoreAudio</source>
-        <translation type="unfinished"></translation>
+        <translation>コア　オーディオ</translation>
     </message>
     <message>
         <source>Disabled</source>
-        <translation type="unfinished"></translation>
+        <translation>無効</translation>
     </message>
     <message>
         <source>System Default</source>
@@ -1451,103 +1451,103 @@
     </message>
     <message>
         <source>Play head follows cursor position</source>
-        <translation type="unfinished"></translation>
+        <translation>再生の先頭がカーソルの位置に追う</translation>
     </message>
     <message>
         <source>Preroll</source>
-        <translation type="unfinished"></translation>
+        <translation>プリロール</translation>
     </message>
     <message>
         <source>Destructive Recording</source>
-        <translation type="unfinished"></translation>
+        <translation>破壊的な録音</translation>
     </message>
     <message>
         <source>Play only visible portion of the audio</source>
-        <translation type="unfinished"></translation>
+        <translation>表示されてるオーディオの部分のみを再生</translation>
     </message>
     <message>
         <source>Select Playback device</source>
-        <translation type="unfinished"></translation>
+        <translation>再生デバイスを選択する</translation>
     </message>
     <message>
         <source>Record Device</source>
-        <translation type="unfinished"></translation>
+        <translation>録音デバイス</translation>
     </message>
     <message>
         <source>Select record device</source>
-        <translation type="unfinished"></translation>
+        <translation>録音デバイスを選択する</translation>
     </message>
     <message>
         <source>Preroll Time</source>
-        <translation type="unfinished"></translation>
+        <translation>プリロール時間</translation>
     </message>
     <message>
         <source>Sets the preroll time.</source>
-        <translation type="unfinished"></translation>
+        <translation>プリロール時間を設定する</translation>
     </message>
     <message>
         <source>Sample Rate</source>
-        <translation type="unfinished"></translation>
+        <translation>サンプルレート</translation>
     </message>
     <message>
         <source>Select the mixer sample rate</source>
-        <translation type="unfinished"></translation>
+        <translation>ミキサーサンプルレートを選択する</translation>
     </message>
     <message>
         <source>Buffer Size</source>
-        <translation type="unfinished"></translation>
+        <translation>バッファーのサイズ</translation>
     </message>
     <message>
         <source>128 samples</source>
-        <translation type="unfinished"></translation>
+        <translation>128 samples</translation>
     </message>
     <message>
         <source>256 samples</source>
-        <translation type="unfinished"></translation>
+        <translation>256 samples</translation>
     </message>
     <message>
         <source>512 samples</source>
-        <translation type="unfinished"></translation>
+        <translation>512 samples</translation>
     </message>
     <message>
         <source>1024 samples</source>
-        <translation type="unfinished"></translation>
+        <translation>1024 samples</translation>
     </message>
     <message>
         <source>2048 samples</source>
-        <translation type="unfinished"></translation>
+        <translation>2048 samples</translation>
     </message>
     <message>
         <source>Select the mixer backend API</source>
-        <translation type="unfinished"></translation>
+        <translation>ミキサーバックエンドのAPIを選択する</translation>
     </message>
     <message>
         <source>samples</source>
-        <translation type="unfinished"></translation>
+        <translation>サンプル</translation>
     </message>
     <message>
         <source>Playback Device</source>
-        <translation type="unfinished"></translation>
+        <translation>再生デバイス</translation>
     </message>
     <message>
         <source>%1 channels</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 チャンネル</translation>
     </message>
     <message>
         <source>%1 s</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 秒</translation>
     </message>
     <message>
         <source>Custom</source>
-        <translation type="unfinished">カスタム</translation>
+        <translation>カスタム</translation>
     </message>
     <message>
         <source>No Devices Found</source>
-        <translation type="unfinished"></translation>
+        <translation>デバイス見つかりません</translation>
     </message>
     <message>
         <source>No common sampling rate</source>
-        <translation type="unfinished"></translation>
+        <translation>共通サンプルレートがありません</translation>
     </message>
 </context>
 <context>
@@ -1638,59 +1638,59 @@
     </message>
     <message>
         <source>Spectrogram Presets</source>
-        <translation type="unfinished"></translation>
+        <translation>スペクトルグラムのプリセット</translation>
     </message>
     <message>
         <source>Select spectrogram preset</source>
-        <translation type="unfinished"></translation>
+        <translation>スペクトルグラムを選択する</translation>
     </message>
     <message>
         <source>Number of bins</source>
-        <translation type="unfinished"></translation>
+        <translation>ビンの数</translation>
     </message>
     <message>
         <source>Window Size</source>
-        <translation type="unfinished"></translation>
+        <translation>ウィンドーの大きさ</translation>
     </message>
     <message>
         <source>Dynamic Range</source>
-        <translation type="unfinished"></translation>
+        <translation>ダイナミックレンジ</translation>
     </message>
     <message>
         <source>Window Type</source>
-        <translation type="unfinished"></translation>
+        <translation>ウィンドータイプ</translation>
     </message>
     <message>
         <source>Select the windowing function type. Window functions are used in signal processing to minimize the effect of spectral leakages</source>
-        <translation type="unfinished"></translation>
+        <translation>ウィンドーの機能の種類を選択してください。ウィンドーの機能は信号処理する際スペクトル漏れを減らす</translation>
     </message>
     <message>
         <source>Color Scheme</source>
-        <translation type="unfinished"></translation>
+        <translation>配色</translation>
     </message>
     <message>
         <source>Select Spectrogram Color Scheme</source>
-        <translation type="unfinished"></translation>
+        <translation>スペクトルグラムの配色を選択する</translation>
     </message>
     <message>
         <source>Sets the spectrogram range normalization on/off</source>
-        <translation type="unfinished"></translation>
+        <translation>スペクトルグラムの正常化範囲を設定する</translation>
     </message>
     <message>
         <source>Select the number of frequency bins to be used to construct the spectrogram</source>
-        <translation type="unfinished"></translation>
+        <translation>スペクトルグラム作成に端数ビンの数を選択する</translation>
     </message>
     <message>
         <source>Select spectrogram dynamic range. The chosen value will be used as lower energy displayed in the spectrogram</source>
-        <translation type="unfinished"></translation>
+        <translation>スペクトルグラム作成に当たって、端数ビンの数を選択する。この値はスペクトルグラムに表示される低いエネルギーとして使われます</translation>
     </message>
     <message>
         <source>Select spectrogram window size. The window size is a percentage of two times the number of bins</source>
-        <translation type="unfinished"></translation>
+        <translation>スペクトルグラムウィンドーの大きさを選択する。この値はビン数の2倍の比率になります</translation>
     </message>
     <message>
         <source>Number of Bins</source>
-        <translation type="unfinished"></translation>
+        <translation>ビン数</translation>
     </message>
 </context>
 <context>
@@ -1701,67 +1701,67 @@
     </message>
     <message>
         <source>Learn Spelling</source>
-        <translation>綴りを記憶</translation>
+        <translation>綴りを覚える</translation>
     </message>
     <message>
         <source>mil </source>
-        <translation>ミル</translation>
+        <translation>mil </translation>
     </message>
     <message>
         <source>milhão </source>
-        <translation>100万</translation>
+        <translation>milhão </translation>
     </message>
     <message>
         <source>bilhão </source>
-        <translation>10億</translation>
+        <translation>bilhão </translation>
     </message>
     <message>
         <source>trilhão </source>
-        <translation>1兆</translation>
+        <translation>trilhão </translation>
     </message>
     <message>
         <source>quatrilhão </source>
-        <translation>1000兆</translation>
+        <translation>quatrilhão </translation>
     </message>
     <message>
         <source>quintilhão </source>
-        <translation></translation>
+        <translation>quintilhão </translation>
     </message>
     <message>
         <source>sextilhão </source>
-        <translation></translation>
+        <translation>sextilhão </translation>
     </message>
     <message>
         <source>setilhão </source>
-        <translation></translation>
+        <translation>setilhão </translation>
     </message>
     <message>
         <source>milhões </source>
-        <translation></translation>
+        <translation>milhões </translation>
     </message>
     <message>
         <source>bilhões </source>
-        <translation></translation>
+        <translation>bilhões </translation>
     </message>
     <message>
         <source>trilhões </source>
-        <translation></translation>
+        <translation>trilhões </translation>
     </message>
     <message>
         <source>quadrilhões </source>
-        <translation></translation>
+        <translation>quadrilhões </translation>
     </message>
     <message>
         <source>quintilhões </source>
-        <translation></translation>
+        <translation>quintilhões </translation>
     </message>
     <message>
         <source>sextilhões </source>
-        <translation></translation>
+        <translation>sextilhões </translation>
     </message>
     <message>
         <source>setilhões </source>
-        <translation></translation>
+        <translation>setilhões </translation>
     </message>
     <message>
         <source>zero</source>
@@ -1773,151 +1773,151 @@
     </message>
     <message>
         <source>cento </source>
-        <translation>百</translation>
+        <translation>cento </translation>
     </message>
     <message>
         <source>cem </source>
-        <translation></translation>
+        <translation>cem </translation>
     </message>
     <message>
         <source>duzentos </source>
-        <translation></translation>
+        <translation>duzentos </translation>
     </message>
     <message>
         <source>trezentos </source>
-        <translation></translation>
+        <translation>trezentos </translation>
     </message>
     <message>
         <source>quatrocentos </source>
-        <translation></translation>
+        <translation>quatrocentos </translation>
     </message>
     <message>
         <source>quinhentos </source>
-        <translation></translation>
+        <translation>quinhentos </translation>
     </message>
     <message>
         <source>seiscentos </source>
-        <translation></translation>
+        <translation>seiscentos </translation>
     </message>
     <message>
         <source>setecentos </source>
-        <translation></translation>
+        <translation>setecentos </translation>
     </message>
     <message>
         <source>oitocentos </source>
-        <translation></translation>
+        <translation>oitocentos </translation>
     </message>
     <message>
         <source>novecentos </source>
-        <translation></translation>
+        <translation>novecentos </translation>
     </message>
     <message>
         <source>dez </source>
-        <translation></translation>
+        <translation>dez </translation>
     </message>
     <message>
         <source>onze </source>
-        <translation></translation>
+        <translation>onze </translation>
     </message>
     <message>
         <source>doze </source>
-        <translation></translation>
+        <translation>doze </translation>
     </message>
     <message>
         <source>treze </source>
-        <translation></translation>
+        <translation>treze </translation>
     </message>
     <message>
         <source>quatorze </source>
-        <translation></translation>
+        <translation>quatorze </translation>
     </message>
     <message>
         <source>quinze </source>
-        <translation></translation>
+        <translation>quinze </translation>
     </message>
     <message>
         <source>dezesseis </source>
-        <translation></translation>
+        <translation>dezesseis </translation>
     </message>
     <message>
         <source>dezessete </source>
-        <translation></translation>
+        <translation>dezessete </translation>
     </message>
     <message>
         <source>dezoito </source>
-        <translation></translation>
+        <translation>dezoito </translation>
     </message>
     <message>
         <source>dezenove </source>
-        <translation></translation>
+        <translation>dezenove </translation>
     </message>
     <message>
         <source>vinte </source>
-        <translation></translation>
+        <translation>vinte </translation>
     </message>
     <message>
         <source>trinta </source>
-        <translation></translation>
+        <translation>trinta </translation>
     </message>
     <message>
         <source>quarenta </source>
-        <translation></translation>
+        <translation>quarenta </translation>
     </message>
     <message>
         <source>cinquenta </source>
-        <translation></translation>
+        <translation>cinquenta </translation>
     </message>
     <message>
         <source>sessenta </source>
-        <translation></translation>
+        <translation>sessenta </translation>
     </message>
     <message>
         <source>setenta </source>
-        <translation></translation>
+        <translation>setenta </translation>
     </message>
     <message>
         <source>oitenta </source>
-        <translation></translation>
+        <translation>oitenta </translation>
     </message>
     <message>
         <source>noventa </source>
-        <translation></translation>
+        <translation>noventa </translation>
     </message>
     <message>
         <source>um </source>
-        <translation></translation>
+        <translation>um </translation>
     </message>
     <message>
         <source>dois </source>
-        <translation></translation>
+        <translation>dois </translation>
     </message>
     <message>
         <source>três </source>
-        <translation></translation>
+        <translation>três </translation>
     </message>
     <message>
         <source>quatro </source>
-        <translation></translation>
+        <translation>quatro </translation>
     </message>
     <message>
         <source>cinco </source>
-        <translation></translation>
+        <translation>cinco </translation>
     </message>
     <message>
         <source>seis </source>
-        <translation></translation>
+        <translation>seis </translation>
     </message>
     <message>
         <source>sete </source>
-        <translation></translation>
+        <translation>sete </translation>
     </message>
     <message>
         <source>oito </source>
-        <translation></translation>
+        <translation>oito </translation>
     </message>
     <message>
         <source>nove </source>
-        <translation></translation>
+        <translation>nove </translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
- Modified existing translations.
- Removed and updated/added Japanese translations for all entries marked
"unfinished".
- Changed instances of software name ("ocenaudio") to exact same as
original English version, instead of Japanese katakana.